### PR TITLE
runner: Fix build and use ErrorPrinter

### DIFF
--- a/gml/Cargo.toml
+++ b/gml/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2018"
 
 [dependencies]
 gml-meta = { path = "meta" }
+project = { path = "../project" }
 
 [target.wasm32-unknown-unknown.dependencies]
 wasm-host = { path = "../wasm-host" }

--- a/gml/src/front/action_ast.rs
+++ b/gml/src/front/action_ast.rs
@@ -1,0 +1,61 @@
+use crate::symbol::Symbol;
+use crate::front::{ast, Span};
+
+pub enum Action {
+    Error,
+    Normal {
+        question: Option<Box<Question>>,
+        execution: Exec,
+        target: Option<i32>,
+        relative: Option<bool>,
+        arguments: Box<[Argument]>,
+    },
+    Block {
+        body: Box<[(Action, Span)]>,
+    },
+    Exit,
+    Repeat {
+        count: Box<(ast::Expr, Span)>,
+        body: Box<(Action, Span)>,
+    },
+    Variable {
+        target: i32,
+        relative: bool,
+        variable: Box<(ast::Expr, Span)>,
+        value: Box<(ast::Expr, Span)>,
+    },
+    Code {
+        target: i32,
+        code: Box<(ast::Stmt, Span)>,
+    },
+}
+
+pub struct Question {
+    pub negate: bool,
+    pub true_action: (Action, Span),
+    pub false_action: Option<(Action, Span)>,
+}
+
+pub enum Exec {
+    Function(Symbol),
+    Code(Box<(ast::Stmt, Span)>),
+}
+
+pub enum Argument {
+    Error,
+    Expr(Box<(ast::Expr, Span)>),
+    String(Symbol),
+    Bool(bool),
+    Menu(i32),
+    Sprite(i32),
+    Sound(i32),
+    Background(i32),
+    Path(i32),
+    Script(i32),
+    Object(i32),
+    Room(i32),
+    Font(i32),
+    Color(u32),
+    Timeline(i32),
+    FontString(Symbol),
+}

--- a/gml/src/front/action_parser.rs
+++ b/gml/src/front/action_parser.rs
@@ -1,0 +1,486 @@
+use std::{slice, str, str::FromStr};
+
+use project::{Action, action_kind, action_type, argument_type};
+
+use crate::symbol::Symbol;
+use crate::front::{ast, Lexer, Parser, Span, ErrorHandler};
+
+pub struct ActionParser<'s, 'e> {
+    reader: slice::Iter<'s, Action>,
+    errors: &'e mut dyn ErrorHandler,
+
+    current: Option<&'s Action>,
+    span: Span,
+}
+
+impl<'s, 'e> ActionParser<'s, 'e> {
+    pub fn new(
+        reader: slice::Iter<'s, Action>,
+        errors: &'e mut dyn ErrorHandler
+    ) -> ActionParser<'s, 'e> {
+        let mut parser = ActionParser {
+            reader,
+            errors,
+
+            current: None,
+            span: Span { low: 0, high: 0 },
+        };
+
+        parser.advance_action();
+        parser
+    }
+
+    pub fn parse_event(&mut self) -> (ast::Action, Span) {
+        let low = self.span.low;
+        let mut high = low;
+
+        let mut actions = vec![];
+        while self.current.is_some() {
+            let (action, span) = self.parse_action();
+            actions.push((action, span));
+            high = span.high;
+        }
+
+        let span = Span { low, high };
+        (ast::Action::Block { body: actions.into_boxed_slice() }, span)
+    }
+
+    fn parse_action(&mut self) -> (ast::Action, Span) {
+        let action_kind = match self.current {
+            Some(action) => action.action_kind,
+            None => {
+                // Allow callers to expect an action when there are none left.
+                // This enables cases like `[Question] [End of event]`.
+                let span = Span { low: self.span.low, high: self.span.low };
+                return (ast::Action::Block { body: Box::new([]) }, span)
+            }
+        };
+
+        match action_kind {
+            action_kind::NORMAL => self.parse_normal(),
+            action_kind::BEGIN => self.parse_block(),
+            action_kind::EXIT => self.parse_exit(),
+            action_kind::REPEAT => self.parse_repeat(),
+            action_kind::VARIABLE => self.parse_variable(),
+            action_kind::CODE => self.parse_code(),
+
+            action_kind::ELSE |
+            action_kind::PLACEHOLDER |
+            action_kind::SEPARATOR |
+            action_kind::LABEL => {
+                self.advance_action();
+                self.parse_action()
+            }
+
+            _ => {
+                let span = self.span;
+                self.advance_action();
+
+                self.errors.error(span, "unexpected action kind");
+                (ast::Action::Error, span)
+            }
+        }
+    }
+
+    fn parse_normal(&mut self) -> (ast::Action, Span) {
+        let low = self.span.low;
+        let mut high = self.span.high;
+        let mut offset = low;
+
+        let action = self.current.unwrap();
+        self.advance_action();
+
+        let question = if action.is_question { Some(action.negate) } else { None };
+
+        let execution = match action.action_type {
+            action_type::FUNCTION => {
+                // Actions may contain invalid UTF-8.
+                let function = String::from_utf8_lossy(&action.name);
+                offset += action.name.len();
+
+                ast::Exec::Function(Symbol::intern(&function))
+            }
+
+            action_type::CODE => {
+                let reader = Lexer::new(&action.code, offset);
+                let mut parser = Parser::new(reader, self.errors);
+                let program = Box::new(parser.parse_program());
+                offset += action.code.len();
+
+                ast::Exec::Code(program)
+            }
+
+            // advance_action skips comments, etc.; anything else is a corrupt action.
+            _ => {
+                let span = Span { low, high };
+                return (ast::Action::Error, span)
+            }
+        };
+
+        let target = if action.has_target { Some(action.target) } else { None };
+        let relative = if action.has_relative { Some(action.relative) } else { None };
+
+        let parameters = action.parameters.iter();
+        let source = action.arguments.iter();
+        let len = action.parameters_used as usize;
+        let arguments: Vec<_> = Iterator::zip(parameters, source).take(len)
+            .map(|(&param, source)| {
+                let argument = self.parse_argument(param, source, offset);
+                offset += source.len();
+
+                argument
+            })
+            .collect();
+        let arguments = arguments.into_boxed_slice();
+
+        let question = question.map(|negate| {
+            let (true_action, true_span) = self.parse_action();
+            high = true_span.high;
+
+            let false_action = match self.current {
+                Some(Action { action_kind: action_kind::ELSE, .. }) => {
+                    self.advance_action();
+
+                    let (false_action, false_span) = self.parse_action();
+                    high = false_span.high;
+
+                    Some((false_action, false_span))
+                }
+                _ => None,
+            };
+            Box::new(ast::Question {
+                negate,
+                true_action: (true_action, true_span),
+                false_action,
+            })
+        });
+
+        let span = Span { low, high };
+        (ast::Action::Normal { question, execution, target, relative, arguments }, span)
+    }
+
+    fn parse_argument(&mut self, param: u32, source: &[u8], offset: usize) -> ast::Argument {
+        // Decode a valid UTF-8 prefix of the argument.
+        // Anything after that would be ignored by integer parsing anyway.
+        let source_str = str::from_utf8(source).unwrap_or_else(move |error| {
+            let (valid, _) = source.split_at(error.valid_up_to());
+            unsafe { str::from_utf8_unchecked(valid) }
+        });
+
+        let argument = match param {
+            argument_type::EXPR => {
+                let reader = Lexer::new(source, offset);
+                let mut parser = Parser::new(reader, self.errors);
+                ast::Argument::Expr(Box::new(parser.parse_expression(0)))
+            }
+
+            argument_type::STRING => {
+                // String literals may contain invalid UTF-8.
+                let string = String::from_utf8_lossy(&source);
+                ast::Argument::String(Symbol::intern(&string))
+            }
+
+            // Select EXPR or STRING based on whether the argument starts with a quote.
+            argument_type::BOTH => {
+                match source.first().copied() {
+                    Some(b'"') => {
+                        let reader = Lexer::new(source, offset);
+                        let mut parser = Parser::new(reader, self.errors);
+                        ast::Argument::Expr(Box::new(parser.parse_expression(0)))
+                    }
+                    _ => {
+                        // String literals may contain invalid UTF-8.
+                        let string = String::from_utf8_lossy(&source);
+                        ast::Argument::String(Symbol::intern(&string))
+                    }
+                }
+            }
+
+            argument_type::BOOL => {
+                let value = u32::from_str(source_str);
+                match value {
+                    Ok(0) => ast::Argument::Bool(false),
+                    Ok(1) => ast::Argument::Bool(true),
+                    _ => ast::Argument::Error
+                }
+            }
+
+            argument_type::MENU => {
+                let value = i32::from_str(source_str);
+                value.map(ast::Argument::Menu).unwrap_or(ast::Argument::Error)
+            }
+
+            argument_type::SPRITE => {
+                let value = i32::from_str(source_str);
+                value.map(ast::Argument::Sprite).unwrap_or(ast::Argument::Error)
+            }
+
+            argument_type::SOUND => {
+                let value = i32::from_str(source_str);
+                value.map(ast::Argument::Sound).unwrap_or(ast::Argument::Error)
+            }
+
+            argument_type::BACKGROUND => {
+                let value = i32::from_str(source_str);
+                value.map(ast::Argument::Background).unwrap_or(ast::Argument::Error)
+            }
+
+            argument_type::PATH => {
+                let value = i32::from_str(source_str);
+                value.map(ast::Argument::Path).unwrap_or(ast::Argument::Error)
+            }
+
+            argument_type::SCRIPT => {
+                let value = i32::from_str(source_str);
+                value.map(ast::Argument::Script).unwrap_or(ast::Argument::Error)
+            }
+
+            argument_type::OBJECT => {
+                let value = i32::from_str(source_str);
+                value.map(ast::Argument::Object).unwrap_or(ast::Argument::Error)
+            }
+
+            argument_type::ROOM => {
+                let value = i32::from_str(source_str);
+                value.map(ast::Argument::Room).unwrap_or(ast::Argument::Error)
+            }
+
+            argument_type::FONT => {
+                let value = i32::from_str(source_str);
+                value.map(ast::Argument::Font).unwrap_or(ast::Argument::Error)
+            }
+
+            argument_type::COLOR => {
+                let value = u32::from_str(source_str);
+                value.map(ast::Argument::Color).unwrap_or(ast::Argument::Error)
+            }
+
+            argument_type::TIMELINE => {
+                let value = i32::from_str(source_str);
+                value.map(ast::Argument::Timeline).unwrap_or(ast::Argument::Error)
+            }
+
+            argument_type::FONT_STRING => {
+                ast::Argument::FontString(Symbol::intern(source_str))
+            }
+
+            _ => ast::Argument::Error,
+        };
+
+        if let ast::Argument::Error = argument {
+            let span = Span { low: offset, high: offset };
+            self.errors.error(span, "corrupt argument");
+        }
+
+        argument
+    }
+
+    fn parse_block(&mut self) -> (ast::Action, Span) {
+        let low = self.span.low;
+        self.advance_action();
+
+        let mut actions = vec![];
+        loop {
+            match self.current {
+                Some(Action { action_kind: action_kind::END, .. }) | None => break,
+                _ => (),
+            }
+
+            let (action, span) = self.parse_action();
+            actions.push((action, span));
+        }
+        let body = actions.into_boxed_slice();
+
+        let high = self.span.high;
+        self.advance_action();
+
+        let span = Span { low, high };
+        (ast::Action::Block { body }, span)
+    }
+
+    fn parse_exit(&mut self) -> (ast::Action, Span) {
+        let span = self.span;
+        self.advance_action();
+        (ast::Action::Exit, span)
+    }
+
+    fn parse_repeat(&mut self) -> (ast::Action, Span) {
+        let low = self.span.low;
+        let mut high = self.span.high;
+        let offset = low;
+
+        let action = self.current.unwrap();
+        self.advance_action();
+
+        if action.parameters_used != 1 {
+            let span = Span { low, high };
+            self.errors.error(span, "wrong number of arguments");
+            return (ast::Action::Error, span);
+        }
+
+        let parameters = action.parameters.iter();
+        let source = action.arguments.iter();
+        let len = action.parameters_used as usize;
+        let mut arguments = Iterator::zip(parameters, source).take(len);
+
+        let (&parameter, source) = arguments.next().unwrap();
+        let count = match parameter {
+            argument_type::EXPR => {
+                let reader = Lexer::new(source, offset);
+                let mut parser = Parser::new(reader, self.errors);
+                Box::new(parser.parse_expression(0))
+            }
+
+            _ => {
+                let span = Span { low, high };
+                self.errors.error(span, "expected an expression");
+                Box::new((ast::Expr::Error, self.span))
+            }
+        };
+
+        let (body, body_span) = self.parse_action();
+        let body = Box::new((body, body_span));
+        high = body_span.high;
+
+        let span = Span { low, high };
+        (ast::Action::Repeat { count, body }, span)
+    }
+
+    fn parse_variable(&mut self) -> (ast::Action, Span) {
+        let low = self.span.low;
+        let high = self.span.high;
+        let offset = low;
+
+        let action = self.current.unwrap();
+        self.advance_action();
+
+        if !action.has_target {
+            let span = Span { low, high };
+            self.errors.error(span, "expected a target");
+            return (ast::Action::Error, span);
+        }
+        let target = action.target;
+
+        if !action.has_relative {
+            let span = Span { low, high };
+            self.errors.error(span, "expected relative");
+            return (ast::Action::Error, span);
+        }
+        let relative = action.relative;
+
+        let len = action.parameters_used as usize;
+        if len != 2 {
+            let span = Span { low, high };
+            self.errors.error(span, "wrong number of arguments");
+            return (ast::Action::Error, span);
+        }
+
+        let parameters = action.parameters.iter();
+        let source = action.arguments.iter();
+        let mut arguments = Iterator::zip(parameters, source).take(len);
+
+        let (&parameter, source) = arguments.next().unwrap();
+        let variable = match parameter {
+            argument_type::STRING => {
+                let reader = Lexer::new(source, offset);
+                let mut parser = Parser::new(reader, self.errors);
+                Box::new(parser.parse_expression(0))
+            }
+
+            _ => {
+                let span = Span { low, high };
+                self.errors.error(span, "expected a variable");
+                Box::new((ast::Expr::Error, self.span))
+            }
+        };
+
+        let (&parameter, source) = arguments.next().unwrap();
+        let value = match parameter {
+            argument_type::EXPR => {
+                let reader = Lexer::new(source, 0);
+                let mut parser = Parser::new(reader, self.errors);
+                Box::new(parser.parse_expression(0))
+            }
+
+            _ => {
+                let span = Span { low, high };
+                self.errors.error(span, "expected an expression");
+                Box::new((ast::Expr::Error, self.span))
+            }
+        };
+
+        let span = Span { low, high };
+        (ast::Action::Variable { target, relative, variable, value }, span)
+    }
+
+    fn parse_code(&mut self) -> (ast::Action, Span) {
+        let low = self.span.low;
+        let high = self.span.high;
+        let offset = low;
+
+        let action = self.current.unwrap();
+        self.advance_action();
+
+        if !action.has_target {
+            let span = Span { low, high };
+            self.errors.error(span, "expected a target");
+            return (ast::Action::Error, span);
+        }
+        let target = action.target;
+
+        let len = action.parameters_used as usize;
+        if len != 1 {
+            let span = Span { low, high };
+            self.errors.error(span, "wrong number of arguments");
+            return (ast::Action::Error, span);
+        }
+
+        let parameters = action.parameters.iter();
+        let source = action.arguments.iter();
+        let mut arguments = Iterator::zip(parameters, source).take(len);
+
+        let (&parameter, source) = arguments.next().unwrap();
+        let code = match parameter {
+            argument_type::STRING => {
+                let reader = Lexer::new(source, offset);
+                let mut parser = Parser::new(reader, self.errors);
+                Box::new(parser.parse_program())
+            }
+
+            _ => {
+                let span = Span { low, high };
+                self.errors.error(span, "expected an expression");
+                Box::new((ast::Stmt::Error(ast::Expr::Error), self.span))
+            }
+        };
+
+        let span = Span { low, high };
+        (ast::Action::Code { target, code }, span)
+    }
+
+    fn advance_action(&mut self) {
+        loop {
+            self.span = Span { low: self.span.high, high: self.span.high };
+            self.current = self.reader.next();
+
+            let action = match self.current {
+                Some(action) => action,
+                None => break,
+            };
+            self.span.high += match (action.action_kind, action.action_type) {
+                (action_kind::NORMAL, action_type::FUNCTION) => action.name.len(),
+                (action_kind::NORMAL, action_type::CODE) => action.code.len(),
+                (_, _) => 0,
+            };
+            self.span.high += action.arguments[..action.parameters_used as usize].iter()
+                .map(|argument| argument.len())
+                .sum::<usize>();
+
+            // Skip comments.
+            match (action.action_kind, action.action_type) {
+                (action_kind::NORMAL, action_type::NONE) => continue,
+                (_, _) => break,
+            }
+        }
+    }
+}

--- a/gml/src/front/ast.rs
+++ b/gml/src/front/ast.rs
@@ -1,6 +1,8 @@
 use crate::symbol::Symbol;
 use crate::front::Span;
 
+pub use crate::front::action_ast::*;
+
 #[derive(PartialEq, Debug)]
 pub enum Stmt {
     Error(Expr),

--- a/gml/src/front/lexer.rs
+++ b/gml/src/front/lexer.rs
@@ -9,8 +9,8 @@ pub struct Lexer<'s> {
 }
 
 impl<'s> Lexer<'s> {
-    pub fn new(source: &'s [u8]) -> Lexer<'s> {
-        Lexer { source, position: 0 }
+    pub fn new(source: &'s [u8], position: usize) -> Lexer<'s> {
+        Lexer { source, position }
     }
 
     pub fn read_token(&mut self) -> (Token, Span) {
@@ -296,7 +296,7 @@ mod tests {
 
     #[test]
     fn spans() {
-        let mut lexer = Lexer::new(b"/* comment */ var foo; foo = 3");
+        let mut lexer = Lexer::new(b"/* comment */ var foo; foo = 3", 0);
 
         assert_eq!(lexer.read_token(), (keyword("var"), span(14, 17)));
         assert_eq!(lexer.read_token(), (ident("foo"), span(18, 21)));

--- a/gml/src/front/mod.rs
+++ b/gml/src/front/mod.rs
@@ -1,39 +1,140 @@
-pub use crate::front::lexer::Lexer;
-pub use crate::front::parser::Parser;
-pub use crate::front::codegen::Codegen;
+use std::iter::{self, FromIterator};
+
+use project::{action_kind, action_type};
 
 use crate::symbol::Symbol;
 
 pub mod token;
 pub mod ast;
+mod action_ast;
 
 mod lexer;
 mod parser;
+mod action_parser;
 mod ssa;
 mod codegen;
 
+pub use lexer::Lexer;
+pub use parser::Parser;
+pub use action_parser::ActionParser;
+pub use codegen::Codegen;
+
+/// A range of positions in an event or script.
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
 pub struct Span {
     pub low: usize,
     pub high: usize,
 }
 
-pub fn compute_lines(source: &[u8]) -> Vec<usize> {
-    let mut lines = vec![0];
-    lines.extend(source.iter().copied()
-        .enumerate()
-        .filter(|&(_, b)| b == b'\n')
-        .map(|(i, _)| i + 1));
-    lines
+/// A user-facing position in an event or script.
+pub struct Position {
+    pub action: Option<usize>,
+    pub argument: Option<usize>,
+    pub line: Option<usize>,
+    pub column: Option<usize>,
 }
 
-pub fn get_position(lines: &[usize], pos: usize) -> (usize, usize) {
-    let line = match lines.binary_search(&pos) {
-        Ok(line) => line,
-        Err(line) => line - 1,
-    };
-    let column = pos - lines[line];
-    (line + 1, column + 1)
+/// Position data for an event or script.
+///
+/// Position data is hierarchical- an event is a sequence of actions, which is a sequence of
+/// arguments, which is a sequence of lines, which is a sequence of columns.
+///
+/// Byte offsets for the start of each item are stored in sorted arrays. This allows us to map from
+/// a single byte offset to user-facing action, argument, line, and column indexes with binary
+/// search.
+///
+/// Converting an absolute index (relative to a whole event) into a local index (relative to the
+/// parent item) works by subtracting the absolute index of the parent item's first child.
+pub struct Lines {
+    /// The byte offset of each action, and the absolute index of its first argument.
+    pub actions: Vec<(usize, usize)>,
+    /// The byte offset of each argument, and the absolute index of its first line.
+    pub arguments: Vec<(usize, usize)>,
+    /// The byte offset of each line. The absolute index of its first column has the same value.
+    pub lines: Vec<usize>,
+}
+
+impl Lines {
+    pub fn from_script(source: &[u8]) -> Lines {
+        let actions = Vec::default();
+        let arguments = Vec::default();
+        let lines = Vec::from_iter(Self::compute_lines(source, 0));
+        Lines { actions, arguments, lines }
+    }
+
+    pub fn from_event(source: &[project::Action]) -> Lines {
+        let mut actions = Vec::default();
+        let mut arguments = Vec::default();
+        let mut lines = Vec::default();
+
+        let mut offset = 0;
+        for action in source {
+            actions.push((offset, arguments.len()));
+
+            offset += match (action.action_kind, action.action_type) {
+                (action_kind::NORMAL, action_type::FUNCTION) => action.name.len(),
+                (action_kind::NORMAL, action_type::CODE) => action.code.len(),
+                (_, _) => 0,
+            };
+
+            for argument in &action.arguments[..action.parameters_used as usize] {
+                arguments.push((offset, lines.len()));
+
+                if action.action_kind == action_kind::CODE {
+                    lines.extend(Self::compute_lines(argument, offset));
+                }
+
+                offset += argument.len();
+            }
+        }
+
+        Lines { actions, arguments, lines }
+    }
+
+    fn compute_lines(source: &[u8], offset: usize) -> impl Iterator<Item = usize> + '_ {
+        let start = iter::once(offset);
+        let newlines = source.iter().copied()
+            .enumerate()
+            .filter(|&(_, b)| b == b'\n')
+            .map(move |(i, _)| offset + i + 1);
+        Iterator::chain(start, newlines)
+    }
+
+    pub fn get_position(&self, pos: usize) -> Position {
+        let action = self.actions.binary_search_by_key(&pos, |&(pos, _)| pos)
+            .map(Some)
+            .unwrap_or_else(|action| action.checked_sub(1));
+        let argument = self.arguments.binary_search_by_key(&pos, |&(pos, _)| pos)
+            .map(Some)
+            .unwrap_or_else(|argument| argument.checked_sub(1));
+        let line = self.lines.binary_search(&pos)
+            .map(Some)
+            .unwrap_or_else(|line| line.checked_sub(1));
+
+        let action_pos = action.map(|action| self.actions[action]);
+        let argument_pos = argument.map(|argument| self.arguments[argument]);
+        let line_pos = line.map(|line| self.lines[line]);
+
+        let action = match action {
+            Some(action) => Some(1 + action),
+            _ => None,
+        };
+        let argument = match (action_pos, argument) {
+            (Some((_, first)), Some(argument)) if first <= argument => Some(1 + argument - first),
+            _ => None,
+        };
+        let line = match (argument_pos, line) {
+            (Some((_, first)), Some(line)) if first <= line => Some(1 + line - first),
+            (_, Some(line)) => Some(1 + line),
+            _ => None,
+        };
+        let column = match line_pos {
+            Some(first) => Some(1 + pos - first),
+            _ => None,
+        };
+
+        Position { action, argument, line, column }
+    }
 }
 
 pub trait ErrorHandler {
@@ -42,24 +143,33 @@ pub trait ErrorHandler {
 
 pub struct ErrorPrinter {
     pub name: Symbol,
-    pub lines: Vec<usize>,
+    pub lines: Lines,
     pub count: u32,
 }
 
 impl ErrorPrinter {
-    pub fn new(name: Symbol, source: &[u8]) -> Self {
-        ErrorPrinter {
-            name,
-            lines: compute_lines(source),
-            count: 0,
-        }
+    pub fn new(name: Symbol, lines: Lines) -> Self {
+        ErrorPrinter { name, lines, count: 0 }
     }
 }
 
 impl ErrorHandler for ErrorPrinter {
     fn error(&mut self, span: Span, message: &str) {
-        let (line, column) = get_position(&self.lines, span.low);
-        eprintln!("error: {}:{}:{}: {}", self.name, line, column, message);
+        let Position { action, argument, line, column } = self.lines.get_position(span.low);
+        eprint!("error in {}", self.name);
+        if let Some(action) = action {
+            eprint!(", action {}", action);
+        }
+        if let (Some(argument), None) = (argument, line) {
+            eprint!(", argument {}", argument);
+        }
+        if let Some(line) = line {
+            eprint!(":{}", line);
+        }
+        if let Some(column) = column {
+            eprint!(":{}", column);
+        }
+        eprintln!(": {}", message);
         self.count += 1;
     }
 }

--- a/gml/src/front/parser.rs
+++ b/gml/src/front/parser.rs
@@ -369,7 +369,7 @@ impl<'s, 'e> Parser<'s, 'e> {
         (ast::Stmt::Case(expr.map(Box::new)), span)
     }
 
-    fn parse_expression(&mut self, min_precedence: usize) -> (ast::Expr, Span) {
+    pub(crate) fn parse_expression(&mut self, min_precedence: usize) -> (ast::Expr, Span) {
         let (mut left, mut left_span, mut parens) = self.parse_prefix_expression();
         while let Some((op, precedence)) = Infix::from_token(self.current) {
             if precedence < min_precedence {
@@ -661,12 +661,13 @@ impl Infix {
 #[cfg(test)]
 mod tests {
     use crate::symbol::Symbol;
-    use crate::front::{Span, Lexer, Parser, ErrorPrinter};
+    use crate::front::{Span, Lexer, Parser, Lines, ErrorPrinter};
     use crate::front::ast::*;
 
-    fn setup(source: &[u8]) -> (ErrorPrinter, Lexer<'_>) {
-        let errors = ErrorPrinter::new(Symbol::intern("<test>"), source);
-        (errors, Lexer::new(source))
+    fn setup<'s>(source: &'s [u8]) -> (ErrorPrinter, Lexer<'s>) {
+        let lines = Lines::from_script(source);
+        let errors = ErrorPrinter::new(Symbol::intern("<test>"), lines);
+        (errors, Lexer::new(source, 0))
     }
 
     fn span(low: usize, high: usize) -> Span {

--- a/gml/src/lib.rs
+++ b/gml/src/lib.rs
@@ -10,7 +10,7 @@ extern crate wasm_host;
 use std::collections::HashMap;
 
 use crate::symbol::Symbol;
-use crate::front::{Lexer, Parser, ErrorHandler, ErrorPrinter};
+use crate::front::{Lexer, Parser, ActionParser, ErrorHandler, Lines, ErrorPrinter};
 use crate::back::ssa;
 use crate::vm::code;
 
@@ -28,6 +28,7 @@ pub mod vm;
 
 /// A GML item definition, used as input to build a project.
 pub enum Item<'a, E> {
+    Event(&'a [project::Action]),
     Script(&'a [u8]),
     Native(vm::ApiFunction<E>, usize, bool),
     Member(Option<vm::GetFunction<E>>, Option<vm::SetFunction<E>>),
@@ -36,10 +37,11 @@ pub enum Item<'a, E> {
 /// Build a GML project.
 pub fn build<E>(items: &HashMap<Symbol, Item<E>>) -> Result<vm::Resources<E>, (u32, vm::Resources<E>)> {
     let prototypes: HashMap<Symbol, ssa::Prototype> = items.iter()
-        .map(|(&name, resource)| match *resource {
-            Item::Script(_) => (name, ssa::Prototype::Script),
-            Item::Native(_, arity, variadic) => (name, ssa::Prototype::Native { arity, variadic }),
-            Item::Member(_, _) => (name, ssa::Prototype::Member),
+        .filter_map(|(&name, resource)| match *resource {
+            Item::Event(_) => None,
+            Item::Script(_) => Some((name, ssa::Prototype::Script)),
+            Item::Native(_, arity, variadic) => Some((name, ssa::Prototype::Native { arity, variadic })),
+            Item::Member(_, _) => Some((name, ssa::Prototype::Member)),
         })
         .collect();
 
@@ -47,10 +49,19 @@ pub fn build<E>(items: &HashMap<Symbol, Item<E>>) -> Result<vm::Resources<E>, (u
     let mut error_count = 0;
     for (&name, item) in items.iter() {
         match *item {
-            Item::Script(source) => {
-                let mut errors = ErrorPrinter::new(name, source);
-                let (function, debug) = compile(&prototypes, source, &mut errors);
+            Item::Event(actions) => {
+                let mut errors = ErrorPrinter::new(name, Lines::from_event(actions));
+                let (function, debug) = compile_event(&prototypes, actions, &mut errors);
                 error_count += errors.count;
+
+                resources.scripts.insert(name, function);
+                resources.debug.insert(name, debug);
+            }
+            Item::Script(source) => {
+                let mut errors = ErrorPrinter::new(name, Lines::from_script(source));
+                let (function, debug) = compile_script(&prototypes, source, &mut errors);
+                error_count += errors.count;
+
                 resources.scripts.insert(name, function);
                 resources.debug.insert(name, debug);
             }
@@ -70,15 +81,28 @@ pub fn build<E>(items: &HashMap<Symbol, Item<E>>) -> Result<vm::Resources<E>, (u
     Ok(resources)
 }
 
-fn compile(
+fn compile_event(
+    prototypes: &HashMap<Symbol, ssa::Prototype>, source: &[project::Action],
+    errors: &mut dyn ErrorHandler
+) -> (code::Function, code::Debug) {
+    let reader = source.iter();
+    let mut parser = ActionParser::new(reader, errors);
+    let program = parser.parse_event();
+    let codegen = front::Codegen::new(prototypes, errors);
+    let program = codegen.compile_event(&program);
+    let codegen = back::Codegen::new();
+    codegen.compile(&program)
+}
+
+fn compile_script(
     prototypes: &HashMap<Symbol, ssa::Prototype>, source: &[u8],
     errors: &mut dyn ErrorHandler
 ) -> (code::Function, code::Debug) {
-    let reader = Lexer::new(source);
+    let reader = Lexer::new(source, 0);
     let mut parser = Parser::new(reader, errors);
     let program = parser.parse_program();
     let codegen = front::Codegen::new(prototypes, errors);
-    let program = codegen.compile(&program);
+    let program = codegen.compile_program(&program);
     let codegen = back::Codegen::new();
     codegen.compile(&program)
 }

--- a/playground/src/lib.rs
+++ b/playground/src/lib.rs
@@ -6,7 +6,7 @@ use std::collections::HashMap;
 use wasm_bindgen::prelude::*;
 use js_sys::Function;
 
-use gml::front::{Span, ErrorHandler, ErrorPrinter};
+use gml::front::{Span, ErrorHandler, Lines, ErrorPrinter};
 use gml::symbol::Symbol;
 use engine::{Engine, instance::Instance};
 
@@ -47,11 +47,12 @@ pub fn run(source: &str) {
 
     if let Err(error) = thread.execute(&mut engine, &resources, script, &[]) {
         let location = resources.debug[&error.symbol].get_location(error.instruction as u32);
-        let source = match items[&error.symbol] {
-            gml::Item::Script(source) => source,
-            _ => b"",
+        let lines = match items[&error.symbol] {
+            gml::Item::Event(source) => Lines::from_event(source),
+            gml::Item::Script(source) => Lines::from_script(source),
+            _ => Lines::from_script(b""),
         };
-        let mut errors = ErrorPrinter::new(error.symbol, source);
+        let mut errors = ErrorPrinter::new(error.symbol, lines);
         let span = Span { low: location as usize, high: location as usize };
         errors.error(span, &format!("{}", error.kind));
     }

--- a/project/Cargo.toml
+++ b/project/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "project"
+version = "0.1.0"
+authors = ["Russell Johnston <rpjohnst@gmail.com>"]
+edition = "2018"
+
+[dependencies]

--- a/project/src/lib.rs
+++ b/project/src/lib.rs
@@ -1,0 +1,64 @@
+#[derive(Default)]
+pub struct Event {
+    pub event_type: u32,
+    pub event_kind: i32,
+    pub actions: Vec<Action>,
+}
+
+#[derive(Default)]
+pub struct Action {
+    pub library: u32,
+    pub action: u32,
+    pub action_kind: u32,
+    pub has_relative: bool,
+    pub is_question: bool,
+    pub has_target: bool,
+    pub action_type: u32,
+    pub name: Vec<u8>,
+    pub code: Vec<u8>,
+    pub parameters_used: u32,
+    pub parameters: Vec<u32>,
+    pub target: i32,
+    pub relative: bool,
+    pub arguments: Vec<Vec<u8>>,
+    pub negate: bool,
+}
+
+pub mod action_kind {
+    pub const NORMAL: u32 = 0;
+    pub const BEGIN: u32 = 1;
+    pub const END: u32 = 2;
+    pub const ELSE: u32 = 3;
+    pub const EXIT: u32 = 4;
+    pub const REPEAT: u32 = 5;
+    pub const VARIABLE: u32 = 6;
+    pub const CODE: u32 = 7;
+    pub const PLACEHOLDER: u32 = 8;
+    pub const SEPARATOR: u32 = 9;
+    pub const LABEL: u32 = 10;
+}
+
+pub mod action_type {
+    pub const NONE: u32 = 0;
+    pub const FUNCTION: u32 = 1;
+    pub const CODE: u32 = 2;
+}
+
+pub mod argument_type {
+    pub const EXPR: u32 = 0;
+    pub const STRING: u32 = 1;
+    pub const BOTH: u32 = 2;
+    pub const BOOL: u32 = 3;
+    pub const MENU: u32 = 4;
+    pub const SPRITE: u32 = 5;
+    pub const SOUND: u32 = 6;
+    pub const BACKGROUND: u32 = 7;
+    pub const PATH: u32 = 8;
+    pub const SCRIPT: u32 = 9;
+    pub const OBJECT: u32 = 10;
+    pub const ROOM: u32 = 11;
+    pub const FONT: u32 = 12;
+    pub const COLOR: u32 = 13;
+    pub const TIMELINE: u32 = 14;
+    pub const FONT_STRING: u32 = 15;
+}


### PR DESCRIPTION
Commit c822dc13 broke the 'runner' crate due to changing the API in
gml::front for error handling and instruction -> source location
conversion.

This commit just copies the new usage from the 'playground' crate.

'cargo build' followed by 'cargo run' works as expected, and prints the
output of the built-in test script. Changing the script to produce a
syntax error or runtime error (I did division by zero) prints out the
correct error message with a line number.