### PR TITLE
Make `vm::Value` non-`Copy`

### DIFF
--- a/engine/src/string.rs
+++ b/engine/src/string.rs
@@ -19,8 +19,8 @@ impl State {
     }
 
     #[gml::function]
-    pub fn real(str: vm::Value) -> f64 {
-        match str.data() {
+    pub fn real(str: vm::ValueRef) -> f64 {
+        match str.decode() {
             vm::Data::Real(real) => real,
             vm::Data::String(str) => str.parse().unwrap_or(0.0),
             _ => 0.0,
@@ -28,8 +28,8 @@ impl State {
     }
 
     #[gml::function]
-    pub fn string(val: vm::Value) -> Symbol {
-        match val.data() {
+    pub fn string(val: vm::ValueRef) -> Symbol {
+        match val.decode() {
             vm::Data::Real(val) => Symbol::intern(&format!("{}", val)),
             vm::Data::String(val) => val,
             _ => Symbol::default(),
@@ -37,10 +37,10 @@ impl State {
     }
 
     #[gml::function]
-    pub fn string_format(val: vm::Value, tot: u32, dec: u32) -> Symbol {
+    pub fn string_format(val: vm::ValueRef, tot: u32, dec: u32) -> Symbol {
         let tot = tot as usize;
         let dec = dec as usize;
-        match val.data() {
+        match val.decode() {
             vm::Data::Real(val) => Symbol::intern(&format!("{:1$.2$}", val, tot, dec)),
             vm::Data::String(val) => val,
             _ => Symbol::default(),

--- a/gml/meta/src/lib.rs
+++ b/gml/meta/src/lib.rs
@@ -212,7 +212,7 @@ impl Function {
         let mut parameters = Vec::new();
         let mut rest = None;
 
-        let value = parse_quote!(vm::Value);
+        let value = parse_quote!(vm::ValueRef);
         let values = parse_quote!(&[vm::Value]);
         while let Some(&param) = inputs.peek() {
             match *param {
@@ -267,7 +267,7 @@ impl Property {
             inputs.next();
         }
 
-        let value_ty = parse_quote!(vm::Value);
+        let value_ty = parse_quote!(vm::ValueRef);
         while let Some(&param) = inputs.peek() {
             match *param {
                 FnArg::Typed(PatType { ref ty, .. }) if *ty == value_ty =>
@@ -371,8 +371,8 @@ pub fn bind(attr: TokenStream, input: TokenStream) -> TokenStream {
     });
     let api_arguments = bindings.functions.iter().map(|function| {
         let api_arguments = function.parameters.iter().enumerate().map(|(i, &param)| match param {
-            Parameter::Direct => quote! { arguments[#i] },
-            Parameter::Convert => quote! { arguments[#i].try_into().unwrap_or_default() },
+            Parameter::Direct => quote! { arguments[#i].borrow() },
+            Parameter::Convert => quote! { arguments[#i].borrow().try_into().unwrap_or_default() },
         });
         quote! { #(#api_arguments,)* }
     });
@@ -465,7 +465,7 @@ pub fn bind(attr: TokenStream, input: TokenStream) -> TokenStream {
                 value.into()
             })*
 
-            #(fn #set(&mut self, entity: vm::Entity, index: usize, value: vm::Value) {
+            #(fn #set(&mut self, entity: vm::Entity, index: usize, value: vm::ValueRef) {
                 #![allow(unused_imports, unused)]
                 use std::convert::TryInto;
 

--- a/gml/src/back/codegen.rs
+++ b/gml/src/back/codegen.rs
@@ -282,7 +282,7 @@ impl Codegen {
 
     fn emit_constant(&mut self, value: vm::Value) -> usize {
         let Self { ref mut constants, ref mut function, .. } = *self;
-        *constants.entry(value).or_insert_with(|| {
+        *constants.entry(value.clone()).or_insert_with(|| {
             let index = function.constants.len();
             function.constants.push(value);
             index

--- a/gml/src/front/codegen.rs
+++ b/gml/src/front/codegen.rs
@@ -739,7 +739,12 @@ impl<'p, 'e> Codegen<'p, 'e> {
             return self.emit_real(0.0, symbol_span.low);
         }
 
-        self.emit_call(op, symbol, args, symbol_span.low)
+        let array = self.emit_call(op, symbol, args, symbol_span.low);
+
+        // TODO: this only happens pre-gms
+        let value = self.emit_unary(ssa::Opcode::ToScalar, array, symbol_span.low);
+        self.emit_unary(ssa::Opcode::Release, array, symbol_span.low);
+        value
     }
 
     fn emit_place(&mut self, expression: &(ast::Expr, Span)) -> Result<Place, PlaceError> {
@@ -955,7 +960,7 @@ impl<'p, 'e> Codegen<'p, 'e> {
         let value = self.emit_binary(ssa::Opcode::LoadIndex, [row, j], location);
 
         // TODO: this only happens pre-gms
-        self.emit_unary(ssa::Opcode::Release, value, location);
+        self.emit_unary(ssa::Opcode::Release, array, location);
         value
     }
 

--- a/gml/src/lib.rs
+++ b/gml/src/lib.rs
@@ -1,6 +1,7 @@
 #![feature(box_patterns)]
 #![feature(box_syntax)]
 #![feature(extern_types)]
+#![feature(untagged_unions)]
 
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 #[macro_use]

--- a/gml/src/vm/array.rs
+++ b/gml/src/vm/array.rs
@@ -1,106 +1,188 @@
-use std::mem;
-use std::rc::Rc;
 use std::cell::UnsafeCell;
-use std::ptr::NonNull;
+use std::mem::ManuallyDrop;
+use std::rc::Rc;
 use crate::vm;
 
-#[derive(Clone)]
-pub struct Array {
-    pub(in crate::vm) data: Rc<UnsafeCell<Vec<Vec<vm::Value>>>>,
-}
+/// A GML array value.
+///
+/// This implementation is shared across all versions of GML, so it has to deal with a few
+/// conflicting requirements. The baseline on top of which all other array behaviors are
+/// implemented is a 1D, ref-counted, mutable vector of `vm::Value`s.
+///
+/// On top of this, earlier GML versions can implement nested "jagged" arrays and various flavors
+/// of copy-on-write behavior.
+#[derive(Clone, Default)]
+#[repr(transparent)]
+pub struct Array { data: Rc<Data> }
 
+/// A borrowed reference to a GML array value.
+///
+/// This type is guaranteed to point to an `array::Data` managed by a `vm::Array`, which lets
+/// clients manipulate arrays with less ref-counting traffic while retaining the ability to
+/// "upgrade" to a full `vm::Array` value.
 #[derive(Copy, Clone)]
-pub struct Row {
-    pub(in crate::vm) data: NonNull<Vec<vm::Value>>,
-}
+#[repr(transparent)]
+pub struct ArrayRef<'a> { data: &'a Data }
 
-#[derive(Copy, Clone, Debug)]
-pub struct BoundsError;
+/// The on-heap portion of a GML array.
+pub type Data = UnsafeCell<Vec<vm::Value>>;
 
 impl Array {
+    /// Construct a jagged array with `value` at `[0, 0]`.
     pub fn from_scalar(value: vm::Value) -> Array {
-        Array { data: Rc::new(UnsafeCell::new(vec![vec![value]])) }
+        let row = vm::Value::from(Array { data: Rc::new(UnsafeCell::new(vec![value])) });
+        Array { data: Rc::new(UnsafeCell::new(vec![row])) }
     }
 
-    pub fn load(&self, i: i32, j: i32) -> Result<vm::Value, BoundsError> {
-        let row = self.load_row(i)?;
-        let value = unsafe { row.load(j)? };
+    /// Convert a `&Array` into an `ArrayRef`.
+    pub fn borrow(&self) -> ArrayRef<'_> { ArrayRef { data: &self.data } }
 
-        Ok(value)
-    }
+    pub fn into_raw(self) -> *const Data { Rc::into_raw(self.data) }
 
-    pub fn store(&self, i: i32, j: i32, value: vm::Value) -> Result<(), BoundsError> {
-        let row = self.store_row(i)?;
-        unsafe { row.store(j, value)? };
-
-        Ok(())
-    }
-
-    pub fn load_row(&self, i: i32) -> Result<Row, BoundsError> {
-        let array = unsafe { &*self.data.get() };
-        let row = array.get(i as usize).ok_or(BoundsError)?;
-
-        unsafe { Ok(mem::transmute::<*const Vec<vm::Value>, Row>(row)) }
-    }
-
-    pub fn store_row(&self, i: i32) -> Result<Row, BoundsError> {
-        let array = unsafe { &mut *self.data.get() };
-
-        if i < 0 {
-            return Err(BoundsError);
-        }
-
-        let i = i as usize;
-        if i >= array.len() {
-            array.resize(i + 1, vec![]);
-        }
-        let row = &mut array[i];
-
-        unsafe { Ok(mem::transmute::<*mut Vec<vm::Value>, Row>(row)) }
-    }
-
-    pub fn into_raw(self) -> *const UnsafeCell<Vec<Vec<vm::Value>>> {
-        Rc::into_raw(self.data)
-    }
-
-    pub fn as_ref(&self) -> &UnsafeCell<Vec<Vec<vm::Value>>> {
-        &self.data
-    }
-
-    pub unsafe fn from_raw(ptr: *const UnsafeCell<Vec<Vec<vm::Value>>>) -> Array {
-        let data = Rc::from_raw(ptr);
-        Array { data }
-    }
-
-    pub unsafe fn clone_from_raw(ptr: *const UnsafeCell<Vec<Vec<vm::Value>>>) -> Array {
-        let raw = Rc::from_raw(ptr);
-        let data = raw.clone();
-        Rc::into_raw(raw);
-        Array { data }
-    }
+    pub unsafe fn from_raw(ptr: *const Data) -> Array { Array { data: Rc::from_raw(ptr) } }
 }
 
-impl Row {
-    pub unsafe fn load(&self, j: i32) -> Result<vm::Value, BoundsError> {
-        let row = self.data.as_ref();
-        let value = row.get(j as usize).ok_or(BoundsError)?;
-
-        Ok(*value)
+impl<'a> ArrayRef<'a> {
+    /// Read an element from a jagged array.
+    pub fn get_jagged(self, i: i32, j: i32) -> Option<vm::Value> {
+        // Safety: `value` does not alias `self`. In the presence of cycles, `row` may, but both
+        // are shared references to `*self.data`.
+        unsafe {
+            let value = &*self.get_raw(i)?;
+            let row = match value.borrow().decode() { vm::Data::Array(r) => r, _ => return None };
+            row.get_flat(j)
+        }
     }
 
-    pub unsafe fn store(&self, j: i32, value: vm::Value) -> Result<(), BoundsError> {
-        let row = &mut *self.data.as_ptr();
-
-        if j < 0 {
-            return Err(BoundsError);
+    /// Read an element from a 1D array.
+    pub fn get_flat(self, j: i32) -> Option<vm::Value> {
+        // Safety: `value` does not alias `self`. In the presence of cycles, cloning its referent
+        // may create a reference that does, but both are shared references to `*self.data.`
+        unsafe {
+            let value = &*self.get_raw(j)?;
+            Some(value.clone())
         }
+    }
 
-        let j = j as usize;
-        if j >= row.len() {
-            row.resize(j + 1, vm::Value::from(0.0));
+    /// Construct a pointer to an element in a 1D array.
+    pub(in crate::vm) fn get_raw(self, j: i32) -> Option<*const vm::Value> {
+        // Safety: Shared references into `*self.data` are discarded before `self` is usable again.
+        unsafe {
+            let vec = &*self.data.get();
+            Some(vec.get(j as usize)?)
         }
-        row[j] = value;
+    }
 
-        Ok(())
+    /// Write an element in a jagged array, growing it if necessary.
+    ///
+    /// Initialize new elements of the outer array with empty arrays, and new elements of the inner
+    /// array with `0.0`.
+    pub fn set_jagged(self, i: i32, j: i32, val: vm::Value) -> Option<()> {
+        // Safety: `value` does not alias `self`. In the presence of cycles, `row` may, but both
+        // are shared references to `*self.data`.
+        //
+        // Calling `set_flat` invalidates `value`, but `value` is no longer live. It would seem
+        // that it could also free `row`'s referent, because `row` only borrows from `value`, but
+        // in that case `self` keeps `row` alive precisely because they do alias.
+        unsafe {
+            let value = &*self.set_raw_outer(i)?;
+            let row = match value.borrow().decode() { vm::Data::Array(r) => r, _ => return None };
+            row.set_flat(j, val)
+        }
+    }
+
+    /// Construct a pointer to a row in a jagged array, growing the outer array if necessary.
+    pub(in crate::vm) fn set_raw_outer(self, j: i32) -> Option<*mut vm::Value> {
+        unsafe { self.set_raw_with(j, || vm::Value::from(Array::default())) }
+    }
+
+    /// Write an element in a 1D array, growing it if necessary.
+    ///
+    /// Initialize new elements with `0.0`.
+    pub fn set_flat(self, j: i32, val: vm::Value) -> Option<()> {
+        // Safety: `value` does not alias `self`. In the presence of cycles, dropping its referent
+        // may create a reference that does, but both are shared references to `*self.data`.
+        //
+        // That drop may decrement the refcount of `*self.data`, but `self` cannot borrow from the
+        // same overwritten element.
+        unsafe {
+            let value = &mut *self.set_raw_with(j, vm::Value::default)?;
+            Some(*value = val)
+        }
+    }
+
+    /// Construct a pointer to an element to an array, initializing new elements with `f()`.
+    ///
+    /// Safety: `f` must not access the interior of `*self.data`.
+    unsafe fn set_raw_with<F>(self, j: i32, f: F) -> Option<*mut vm::Value> where
+        F: FnMut() -> vm::Value
+    {
+        let j = if j < 0 { return None } else { j as usize };
+        // Safety: Unique references into `*self.data` are discarded before `self` is usable again.
+        // The call to `resize_with` ensures that `get_unchecked_mut(j)` is in-bounds.
+        #[allow(unused_unsafe)] unsafe {
+            let vec = &mut *self.data.get();
+            if j >= vec.len() { vec.resize_with(j + 1, f) }
+            Some(vec.get_unchecked_mut(j))
+        }
+    }
+
+    /// Convert this borrowed array into an owned array.
+    pub fn clone(self) -> Array {
+        // Safety: `self.data` is a reference obtained from `Rc::into_raw`,
+        // and `ManuallyDrop` prevents the extra drop.
+        let data = unsafe { ManuallyDrop::new(Rc::from_raw(self.data)) };
+        Array { data: Rc::clone(&data) }
+    }
+
+    pub fn as_raw(self) -> *const Data { self.data }
+
+    pub unsafe fn from_raw(ptr: *const Data) -> ArrayRef<'a> { ArrayRef { data: &*ptr } }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::vm;
+
+    #[test]
+    fn jagged() {
+        let array = vm::Array::from_scalar(vm::Value::from(3.0));
+        let a = array.borrow();
+
+        assert_eq!(a.get_jagged(-1, 0), None);
+        assert_eq!(a.get_jagged(0, -1), None);
+        assert_eq!(a.get_jagged(0, 0), Some(vm::Value::from(3.0)));
+        assert_eq!(a.get_jagged(0, 1), None);
+        assert_eq!(a.get_jagged(1, 0), None);
+
+        assert_eq!(a.set_jagged(0, 3, vm::Value::from(5.0)), Some(()));
+        assert_eq!(a.get_jagged(-1, 0), None);
+        assert_eq!(a.get_jagged(0, -1), None);
+        assert_eq!(a.get_jagged(0, 0), Some(vm::Value::from(3.0)));
+        assert_eq!(a.get_jagged(0, 1), Some(vm::Value::from(0.0)));
+        assert_eq!(a.get_jagged(0, 2), Some(vm::Value::from(0.0)));
+        assert_eq!(a.get_jagged(0, 3), Some(vm::Value::from(5.0)));
+        assert_eq!(a.get_jagged(0, 4), None);
+        assert_eq!(a.get_jagged(1, 0), None);
+
+        assert_eq!(a.set_jagged(3, 5, vm::Value::from(8.0)), Some(()));
+        assert_eq!(a.get_jagged(-1, 0), None);
+        assert_eq!(a.get_jagged(0, -1), None);
+        assert_eq!(a.get_jagged(0, 0), Some(vm::Value::from(3.0)));
+        assert_eq!(a.get_jagged(0, 1), Some(vm::Value::from(0.0)));
+        assert_eq!(a.get_jagged(0, 2), Some(vm::Value::from(0.0)));
+        assert_eq!(a.get_jagged(0, 3), Some(vm::Value::from(5.0)));
+        assert_eq!(a.get_jagged(0, 4), None);
+        assert_eq!(a.get_jagged(1, 0), None);
+        assert_eq!(a.get_jagged(2, 0), None);
+        assert_eq!(a.get_jagged(3, -1), None);
+        assert_eq!(a.get_jagged(3, 0), Some(vm::Value::from(0.0)));
+        assert_eq!(a.get_jagged(3, 1), Some(vm::Value::from(0.0)));
+        assert_eq!(a.get_jagged(3, 2), Some(vm::Value::from(0.0)));
+        assert_eq!(a.get_jagged(3, 3), Some(vm::Value::from(0.0)));
+        assert_eq!(a.get_jagged(3, 4), Some(vm::Value::from(0.0)));
+        assert_eq!(a.get_jagged(3, 5), Some(vm::Value::from(8.0)));
+        assert_eq!(a.get_jagged(3, 6), None);
+        assert_eq!(a.get_jagged(4, 0), None);
     }
 }

--- a/gml/src/vm/debug.rs
+++ b/gml/src/vm/debug.rs
@@ -1,62 +1,58 @@
 use std::fmt;
 use std::collections::HashSet;
-use std::cell::Cell;
+use std::cell::UnsafeCell;
 
 use crate::vm;
 
-pub(in crate::vm) struct Value<'b> {
-    pub(in crate::vm) value: vm::Value,
-    pub(in crate::vm) visited: &'b Cell<HashSet<usize>>,
+pub(in crate::vm) struct Value<'a, 'b> {
+    pub(in crate::vm) value: vm::ValueRef<'a>,
+    pub(in crate::vm) visited: &'b UnsafeCell<HashSet<usize>>,
 }
 
-impl<'b> fmt::Debug for Value<'b> {
+impl<'a, 'b> fmt::Debug for Value<'a, 'b> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let Value { value, visited } = *self;
-        match value.data() {
+        match value.decode() {
             vm::Data::Real(value) => write!(f, "{:?}", value),
             vm::Data::String(value) => write!(f, "{}", value),
-            vm::Data::Array(value) => write!(f, "{:?}", Array(&value, visited)),
+            vm::Data::Array(array) => write!(f, "{:?}", Array { array, visited }),
         }
     }
 }
 
-struct Array<'a, 'b>(&'a vm::Array, &'b Cell<HashSet<usize>>);
+struct Array<'a, 'b> {
+    array: vm::ArrayRef<'a>,
+    visited: &'b UnsafeCell<HashSet<usize>>,
+}
 
 impl<'a, 'b> fmt::Debug for Array<'a, 'b> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let Array(array, visited) = *self;
-        let raw = &*array.data as *const _ as usize;
-        if begin(visited, raw) {
-            let array = unsafe { &*array.data.get() };
-            f.debug_set().entries(array.iter().map(|row| Row(row, visited))).finish()?;
-        } else {
+        let Array { array, visited } = *self;
+        let address = array.as_raw() as usize;
+
+        // Safety: `HashSet::insert` cannot see the `UnsafeCell`.
+        if unsafe {
+            let visited = &mut *visited.get();
+            !visited.insert(address)
+        } {
             write!(f, "{{...}}")?;
-        }
-        end(visited, raw);
-
-        fn begin(visited: &Cell<HashSet<usize>>, address: usize) -> bool {
-            let mut v = visited.take();
-            let i = v.insert(address);
-            visited.set(v);
-            i
+            return Ok(());
         }
 
-        fn end(visited: &Cell<HashSet<usize>>, address: usize) {
-            let mut v = visited.take();
-            v.remove(&address);
-            visited.set(v);
+        // Safety: `ArrayRef::as_raw` is always non-null, and while this iterator creates immutable
+        // references into the array's `UnsafeCell`, no other code can see it.
+        unsafe {
+            let data = &*array.as_raw();
+            let vec = &*data.get();
+            let entries = vec.iter().map(|value| Value { value: value.borrow(), visited });
+            f.debug_set().entries(entries).finish()?;
         }
 
-        Ok(())
-    }
-}
-
-struct Row<'a, 'b>(&'a Vec<vm::Value>, &'b Cell<HashSet<usize>>);
-
-impl<'a, 'b> fmt::Debug for Row<'a, 'b> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let Row(row, visited) = *self;
-        f.debug_set().entries(row.iter().map(|&value| Value { value, visited })).finish()?;
+        // Safety: `HashSet::remove` cannot see the `UnsafeCell`.
+        unsafe {
+            let visited = &mut *visited.get();
+            visited.remove(&address);
+        }
 
         Ok(())
     }
@@ -67,17 +63,14 @@ mod tests {
     use crate::vm;
 
     #[test]
-    fn recursive() -> Result<(), vm::array::BoundsError> {
+    fn recursive() {
         let array = vm::Array::from_scalar(vm::Value::from(1.0));
-        let raw = array.into_raw();
 
-        let array = unsafe { vm::Array::clone_from_raw(raw) };
-        array.store(0, 1, vm::Value::from(unsafe { vm::Array::clone_from_raw(raw) }))?;
-        array.store(0, 2, vm::Value::from(3.0))?;
+        let a = array.borrow();
+        a.set_jagged(0, 1, vm::Value::from(a.clone())).unwrap();
+        a.set_jagged(0, 2, vm::Value::from(3.0)).unwrap();
 
-        let array = vm::Value::from(unsafe { vm::Array::from_raw(raw) });
+        let array = vm::Value::from(array);
         assert_eq!(format!("{:?}", array), "{{1.0, {...}, 3.0}}");
-
-        Ok(())
     }
 }

--- a/gml/src/vm/interpreter.rs
+++ b/gml/src/vm/interpreter.rs
@@ -1,36 +1,51 @@
-use std::{mem, ptr, slice, cmp, fmt, error};
+use std::{mem, ptr, iter, slice, cmp, fmt, error};
 use std::convert::TryFrom;
+use std::mem::ManuallyDrop;
 
 use crate::symbol::Symbol;
-use crate::vm::{self, code};
+use crate::vm::{code, world};
+use crate::vm::{World, Entity, Value, ValueRef, Data, to_i32, to_bool, Array, ArrayRef, Resources};
 
 /// A single thread of GML execution.
 pub struct Thread {
     returns: Vec<(Symbol, usize, usize)>,
     stack: Vec<Register>,
 
-    self_entity: vm::Entity,
-    other_entity: vm::Entity,
+    self_entity: Entity,
+    other_entity: Entity,
 }
 
 extern {
     type Engine;
 }
 
-/// A stack slot for the VM.
+/// A 64-bit stack slot for the VM.
 ///
-/// Each variant should be the same size: 64 bits.
-#[derive(Copy, Clone)]
-pub union Register {
-    /// A language-level value.
-    pub value: vm::Value,
-    /// An intermediate result when working with arrays.
-    pub row: vm::Row,
+/// The distinction between `value` and `value_ref` is entirely for readability, and bytecode often
+/// writes a `value` but reads it as a `value_ref`. (See `Value` and `ValueRef` for justification.)
+/// This enables loads to produce `ValueRef`s rather than cloning, while simultaneously using those
+/// results as operands to many ops, with the usual borrowing rules upheld by codegen.
+#[repr(C)]
+union Register {
+    /// An uninitialized register.
+    uninit: (),
+
+    /// An owned language-level value.
+    value: ManuallyDrop<Value>,
+
+    /// An intermediate result when loading from a scope or array.
+    value_ref: ValueRef<'static>,
+    /// An intermediate result when working with jagged arrays.
+    row: ArrayRef<'static>,
 
     /// An entity id, resolved from an instance or other scope id.
-    pub entity: vm::Entity,
+    entity: Entity,
     /// A pointer into an array of entity ids.
-    pub iterator: ptr::NonNull<vm::Entity>,
+    iterator: ptr::NonNull<Entity>,
+}
+
+impl Default for Register {
+    fn default() -> Self { Register { uninit: () } }
 }
 
 pub struct Error {
@@ -42,9 +57,9 @@ pub struct Error {
 #[derive(Debug)]
 pub enum ErrorKind {
     /// Unary type error.
-    TypeUnary(code::Op, vm::Type),
+    TypeUnary(code::Op, Value),
     /// Binary type error.
-    TypeBinary(code::Op, vm::Type, vm::Type),
+    TypeBinary(code::Op, Value, Value),
     /// Division by zero.
     DivideByZero,
     /// Function call arity mismatch.
@@ -92,806 +107,673 @@ pub const GLOBAL: i32 = -5;
 // -6?
 pub const LOCAL: i32 = -7;
 
-impl Thread {
-    pub fn new() -> Self {
-        Self {
-            returns: vec![],
-            stack: vec![],
+impl Default for Thread {
+    fn default() -> Self {
+        Thread {
+            returns: Vec::default(),
+            stack: Vec::default(),
 
-            self_entity: vm::Entity(0),
-            other_entity: vm::Entity(0),
+            self_entity: Entity(0),
+            other_entity: Entity(0),
         }
     }
+}
 
-    pub fn set_self(&mut self, entity: vm::Entity) {
+impl Thread {
+    pub fn set_self(&mut self, entity: Entity) {
         self.self_entity = entity;
     }
 
-    pub fn set_other(&mut self, entity: vm::Entity) {
+    pub fn set_other(&mut self, entity: Entity) {
         self.other_entity = entity;
     }
 
-    pub fn execute<E: vm::world::Api>(
+    pub fn execute<E: world::Api>(
         &mut self,
-        engine: &mut E, resources: &vm::Resources<E>,
-        symbol: Symbol, arguments: &[vm::Value]
-    ) -> Result<vm::Value, Error> {
+        engine: &mut E, resources: &Resources<E>,
+        symbol: Symbol, arguments: Vec<Value>
+    ) -> Result<Value, Error> {
         let world = E::receivers(engine) as *mut _;
         let engine = unsafe { &mut *(engine as *mut _ as *mut Engine) };
-        let resources = unsafe { &*(resources as *const _ as *const vm::Resources<Engine>) };
-        self.execute_internal(engine, world, resources, symbol, arguments)
+        let resources = unsafe { &*(resources as *const _ as *const Resources<Engine>) };
+        execute_internal(self, engine, world, resources, symbol, arguments)
+    }
+}
+
+fn get_string(value: ValueRef<'_>) -> Symbol {
+    match value.decode() {
+        Data::String(value) => value,
+        _ => unreachable!("expected a string"),
+    }
+}
+
+fn execute_internal<'a>(
+    thread: &mut Thread,
+    engine: &'a mut Engine, world: *mut World, resources: &Resources<Engine>,
+    symbol: Symbol, arguments: Vec<Value>
+) -> Result<Value, Error> {
+    // Enforce that `world` is treated as a reborrow of `engine`.
+    fn constrain<F: for<'a> Fn(&'a mut Engine) -> &'a mut World>(f: F) -> F { f }
+    let world = constrain(move |_| unsafe { &mut *world });
+
+    // Erase the lifetime of a `ValueRef` for use in a `Register`.
+    unsafe fn erase_ref(r: ValueRef<'_>) -> ValueRef<'static> { mem::transmute(r) }
+
+    // Thread state not stored in `thread`:
+    let mut symbol = symbol;
+    let mut function = &resources.scripts[&symbol];
+    let mut instruction = 0;
+    let mut reg_base = thread.stack.len();
+
+    // Don't initialize locals, the compiler handles that.
+    thread.stack.resize_with(reg_base + function.locals as usize, Register::default);
+
+    // Move the arguments onto the stack and initialize any additional parameters to 0.0.
+    let registers = thread.stack[reg_base..][..function.params as usize].iter_mut();
+    let arguments = arguments.into_iter().chain(iter::repeat_with(Value::default));
+    for (reg, arg) in Iterator::zip(registers, arguments) {
+        *reg = Register { value: ManuallyDrop::new(arg) };
     }
 
-    fn execute_internal<'a>(
-        &mut self,
-        engine: &'a mut Engine, world: *mut vm::World, resources: &vm::Resources<Engine>,
-        symbol: Symbol, arguments: &[vm::Value]
-    ) -> Result<vm::Value, Error> {
-        let mut symbol = symbol;
-        let mut function = &resources.scripts[&symbol];
-        let mut instruction = 0;
-        let mut reg_base = self.stack.len();
-
-        let default = Register { value: vm::Value::from(0.0) };
-        self.stack.resize(reg_base + function.locals as usize, default);
-
-        let arg_len = cmp::min(function.params as usize, arguments.len());
-        let arguments = unsafe { mem::transmute::<&[vm::Value], &[Register]>(arguments) };
-        self.stack[reg_base..reg_base + arg_len].copy_from_slice(&arguments[0..arg_len]);
-
-        // Enforce that `world` is treated as a reborrow of `engine`.
-        fn constrain<F: for<'a> Fn(&'a mut Engine) -> &'a mut vm::World>(f: F) -> F { f }
-        let world = constrain(move |_| unsafe { &mut *world });
-
-        loop {
-            let registers = &mut self.stack[reg_base..];
-
-            match function.instructions[instruction].decode() {
-                (code::Op::Imm, t, constant, _) => {
-                    registers[t].value = function.constants[constant];
-                }
-
-                (code::Op::Move, t, s, _) => {
-                    registers[t] = registers[s];
-                }
-
-                (op @ code::Op::Neg, t, a, _) => {
-                    let a = unsafe { registers[a].value };
-                    registers[t].value = match a.data() {
-                        vm::Data::Real(a) => Ok(vm::Value::from(-a)),
-                        a => {
-                            let kind = ErrorKind::TypeUnary(op, a.ty());
-                            Err(Error { symbol, instruction, kind })
-                        }
-                    }?;
-                }
-
-                (op @ code::Op::Not, t, a, _) => {
-                    let a = unsafe { registers[a].value };
-                    registers[t].value = match a.data() {
-                        vm::Data::Real(a) => {
-                            let a = Self::to_bool(a);
-                            Ok(vm::Value::from(!a))
-                        }
-                        a => {
-                            let kind = ErrorKind::TypeUnary(op, a.ty());
-                            Err(Error { symbol, instruction, kind })
-                        }
-                    }?;
-                }
-
-                (op @ code::Op::BitNot, t, a, _) => {
-                    let a = unsafe { registers[a].value };
-                    registers[t].value = match a.data() {
-                        vm::Data::Real(a) => {
-                            let a = Self::to_i32(a);
-                            Ok(vm::Value::from(!a))
-                        }
-                        a => {
-                            let kind = ErrorKind::TypeUnary(op, a.ty());
-                            Err(Error { symbol, instruction, kind })
-                        }
-                    }?;
-                }
-
-                (op @ code::Op::Lt, t, a, b) => {
-                    let a = unsafe { registers[a].value };
-                    let b = unsafe { registers[b].value };
-                    registers[t].value = match (a.data(), b.data()) {
-                        (vm::Data::Real(a), vm::Data::Real(b)) => Ok(vm::Value::from(a < b)),
-                        (vm::Data::String(a), vm::Data::String(b)) => Ok(vm::Value::from(a < b)),
-                        (a, b) => {
-                            let kind = ErrorKind::TypeBinary(op, a.ty(), b.ty());
-                            Err(Error { symbol, instruction, kind })
-                        }
-                    }?;
-                }
-
-                (op @ code::Op::Le, t, a, b) => {
-                    let a = unsafe { registers[a].value };
-                    let b = unsafe { registers[b].value };
-                    registers[t].value = match (a.data(), b.data()) {
-                        (vm::Data::Real(a), vm::Data::Real(b)) => Ok(vm::Value::from(a <= b)),
-                        (vm::Data::String(a), vm::Data::String(b)) => Ok(vm::Value::from(a <= b)),
-                        (a, b) => {
-                            let kind = ErrorKind::TypeBinary(op, a.ty(), b.ty());
-                            Err(Error { symbol, instruction, kind })
-                        }
-                    }?;
-                }
-
-                (code::Op::Eq, t, a, b) => {
-                    let a = unsafe { registers[a].value };
-                    let b = unsafe { registers[b].value };
-                    registers[t].value = vm::Value::from(a == b);
-                }
-
-                (code::Op::Ne, t, a, b) => {
-                    let a = unsafe { registers[a].value };
-                    let b = unsafe { registers[b].value };
-                    registers[t].value = vm::Value::from(a != b);
-                }
-
-                (op @ code::Op::Ge, t, a, b) => {
-                    let a = unsafe { registers[a].value };
-                    let b = unsafe { registers[b].value };
-                    registers[t].value = match (a.data(), b.data()) {
-                        (vm::Data::Real(a), vm::Data::Real(b)) => Ok(vm::Value::from(a >= b)),
-                        (vm::Data::String(a), vm::Data::String(b)) => Ok(vm::Value::from(a >= b)),
-                        (a, b) => {
-                            let kind = ErrorKind::TypeBinary(op, a.ty(), b.ty());
-                            Err(Error { symbol, instruction, kind })
-                        }
-                    }?;
-                }
-
-                (op @ code::Op::Gt, t, a, b) => {
-                    let a = unsafe { registers[a].value };
-                    let b = unsafe { registers[b].value };
-                    registers[t].value = match (a.data(), b.data()) {
-                        (vm::Data::Real(a), vm::Data::Real(b)) => Ok(vm::Value::from(a > b)),
-                        (vm::Data::String(a), vm::Data::String(b)) => Ok(vm::Value::from(a > b)),
-                        (a, b) => {
-                            let kind = ErrorKind::TypeBinary(op, a.ty(), b.ty());
-                            Err(Error { symbol, instruction, kind })
-                        }
-                    }?;
-                }
-
-                (op @ code::Op::Add, t, a, b) => {
-                    let a = unsafe { registers[a].value };
-                    let b = unsafe { registers[b].value };
-                    registers[t].value = match (a.data(), b.data()) {
-                        (vm::Data::Real(a), vm::Data::Real(b)) => Ok(vm::Value::from(a + b)),
-                        (vm::Data::String(a), vm::Data::String(b)) =>
-                            Ok(vm::Value::from(Symbol::intern(&[a, b].concat()))),
-                        (a, b) => {
-                            let kind = ErrorKind::TypeBinary(op, a.ty(), b.ty());
-                            Err(Error { symbol, instruction, kind })
-                        }
-                    }?;
-                }
-
-                (op @ code::Op::Sub, t, a, b) => {
-                    let a = unsafe { registers[a].value };
-                    let b = unsafe { registers[b].value };
-                    registers[t].value = match (a.data(), b.data()) {
-                        (vm::Data::Real(a), vm::Data::Real(b)) => Ok(vm::Value::from(a - b)),
-                        (a, b) => {
-                            let kind = ErrorKind::TypeBinary(op, a.ty(), b.ty());
-                            Err(Error { symbol, instruction, kind })
-                        }
-                    }?;
-                }
-
-                (op @ code::Op::Mul, t, a, b) => {
-                    let a = unsafe { registers[a].value };
-                    let b = unsafe { registers[b].value };
-                    registers[t].value = match (a.data(), b.data()) {
-                        (vm::Data::Real(a), vm::Data::Real(b)) => Ok(vm::Value::from(a * b)),
-                        (vm::Data::Real(a), vm::Data::String(b)) => {
-                            let b: &str = &b;
-                            let t = b.repeat(a as usize);
-                            Ok(vm::Value::from(Symbol::intern(&t)))
-                        }
-                        (a, b) => {
-                            let kind = ErrorKind::TypeBinary(op, a.ty(), b.ty());
-                            Err(Error { symbol, instruction, kind })
-                        }
-                    }?;
-                }
-
-                (op @ code::Op::Div, t, a, b) => {
-                    let a = unsafe { registers[a].value };
-                    let b = unsafe { registers[b].value };
-                    registers[t].value = match (a.data(), b.data()) {
-                        (vm::Data::Real(a), vm::Data::Real(b)) => {
-                            if b == 0.0 {
-                                let kind = ErrorKind::DivideByZero;
-                                return Err(Error { symbol, instruction, kind });
-                            }
-                            Ok(vm::Value::from(a / b))
-                        }
-                        (a, b) => {
-                            let kind = ErrorKind::TypeBinary(op, a.ty(), b.ty());
-                            Err(Error { symbol, instruction, kind })
-                        }
-                    }?;
-                }
-
-                (op @ code::Op::IntDiv, t, a, b) => {
-                    let a = unsafe { registers[a].value };
-                    let b = unsafe { registers[b].value };
-                    registers[t].value = match (a.data(), b.data()) {
-                        (vm::Data::Real(a), vm::Data::Real(b)) => {
-                            if b == 0.0 {
-                                let kind = ErrorKind::DivideByZero;
-                                return Err(Error { symbol, instruction, kind });
-                            }
-                            let t = a / b;
-                            Ok(vm::Value::from(t as i32))
-                        }
-                        (a, b) => {
-                            let kind = ErrorKind::TypeBinary(op, a.ty(), b.ty());
-                            Err(Error { symbol, instruction, kind })
-                        }
-                    }?;
-                }
-
-                (op @ code::Op::Mod, t, a, b) => {
-                    let a = unsafe { registers[a].value };
-                    let b = unsafe { registers[b].value };
-                    registers[t].value = match (a.data(), b.data()) {
-                        (vm::Data::Real(a), vm::Data::Real(b)) => {
-                            if b == 0.0 {
-                                let kind = ErrorKind::DivideByZero;
-                                return Err(Error { symbol, instruction, kind });
-                            }
-                            Ok(vm::Value::from(a % b))
-                        }
-                        (a, b) => {
-                            let kind = ErrorKind::TypeBinary(op, a.ty(), b.ty());
-                            Err(Error { symbol, instruction, kind })
-                        }
-                    }?;
-                }
-
-                (op @ code::Op::And, t, a, b) => {
-                    let a = unsafe { registers[a].value };
-                    let b = unsafe { registers[b].value };
-                    registers[t].value = match (a.data(), b.data()) {
-                        (vm::Data::Real(a), vm::Data::Real(b)) => {
-                            let a = Self::to_bool(a);
-                            let b = Self::to_bool(b);
-                            Ok(vm::Value::from(a && b))
-                        }
-                        (a, b) => {
-                            let kind = ErrorKind::TypeBinary(op, a.ty(), b.ty());
-                            Err(Error { symbol, instruction, kind })
-                        }
-                    }?;
-                }
-
-                (op @ code::Op::Or, t, a, b) => {
-                    let a = unsafe { registers[a].value };
-                    let b = unsafe { registers[b].value };
-                    registers[t].value = match (a.data(), b.data()) {
-                        (vm::Data::Real(a), vm::Data::Real(b)) => {
-                            let a = Self::to_bool(a);
-                            let b = Self::to_bool(b);
-                            Ok(vm::Value::from(a || b))
-                        }
-                        (a, b) => {
-                            let kind = ErrorKind::TypeBinary(op, a.ty(), b.ty());
-                            Err(Error { symbol, instruction, kind })
-                        }
-                    }?;
-                }
-
-                (op @ code::Op::Xor, t, a, b) => {
-                    let a = unsafe { registers[a].value };
-                    let b = unsafe { registers[b].value };
-                    registers[t].value = match (a.data(), b.data()) {
-                        (vm::Data::Real(a), vm::Data::Real(b)) => {
-                            let a = Self::to_bool(a);
-                            let b = Self::to_bool(b);
-                            Ok(vm::Value::from(a != b))
-                        }
-                        (a, b) => {
-                            let kind = ErrorKind::TypeBinary(op, a.ty(), b.ty());
-                            Err(Error { symbol, instruction, kind })
-                        }
-                    }?;
-                }
-
-                (op @ code::Op::BitAnd, t, a, b) => {
-                    let a = unsafe { registers[a].value };
-                    let b = unsafe { registers[b].value };
-                    registers[t].value = match (a.data(), b.data()) {
-                        (vm::Data::Real(a), vm::Data::Real(b)) => {
-                            let a = Self::to_i32(a);
-                            let b = Self::to_i32(b);
-                            Ok(vm::Value::from(a & b))
-                        }
-                        (a, b) => {
-                            let kind = ErrorKind::TypeBinary(op, a.ty(), b.ty());
-                            Err(Error { symbol, instruction, kind })
-                        }
-                    }?;
-                }
-
-                (op @ code::Op::BitOr, t, a, b) => {
-                    let a = unsafe { registers[a].value };
-                    let b = unsafe { registers[b].value };
-                    registers[t].value = match (a.data(), b.data()) {
-                        (vm::Data::Real(a), vm::Data::Real(b)) => {
-                            let a = Self::to_i32(a);
-                            let b = Self::to_i32(b);
-                            Ok(vm::Value::from(a | b))
-                        }
-                        (a, b) => {
-                            let kind = ErrorKind::TypeBinary(op, a.ty(), b.ty());
-                            Err(Error { symbol, instruction, kind })
-                        }
-                    }?;
-                }
-
-                (op @ code::Op::BitXor, t, a, b) => {
-                    let a = unsafe { registers[a].value };
-                    let b = unsafe { registers[b].value };
-                    registers[t].value = match (a.data(), b.data()) {
-                        (vm::Data::Real(a), vm::Data::Real(b)) => {
-                            let a = Self::to_i32(a);
-                            let b = Self::to_i32(b);
-                            Ok(vm::Value::from(a ^ b))
-                        }
-                        (a, b) => {
-                            let kind = ErrorKind::TypeBinary(op, a.ty(), b.ty());
-                            Err(Error { symbol, instruction, kind })
-                        }
-                    }?;
-                }
-
-                (op @ code::Op::ShiftLeft, t, a, b) => {
-                    let a = unsafe { registers[a].value };
-                    let b = unsafe { registers[b].value };
-                    registers[t].value = match (a.data(), b.data()) {
-                        (vm::Data::Real(a), vm::Data::Real(b)) => {
-                            let a = Self::to_i32(a);
-                            let b = Self::to_i32(b);
-                            Ok(vm::Value::from(a << b))
-                        }
-                        (a, b) => {
-                            let kind = ErrorKind::TypeBinary(op, a.ty(), b.ty());
-                            Err(Error { symbol, instruction, kind })
-                        }
-                    }?;
-                }
-
-                (op @ code::Op::ShiftRight, t, a, b) => {
-                    let a = unsafe { registers[a].value };
-                    let b = unsafe { registers[b].value };
-                    registers[t].value = match (a.data(), b.data()) {
-                        (vm::Data::Real(a), vm::Data::Real(b)) => {
-                            let a = Self::to_i32(a);
-                            let b = Self::to_i32(b);
-                            Ok(vm::Value::from(a >> b))
-                        }
-                        (a, b) => {
-                            let kind = ErrorKind::TypeBinary(op, a.ty(), b.ty());
-                            Err(Error { symbol, instruction, kind })
-                        }
-                    }?;
-                }
-
-                (code::Op::DeclareGlobal, name, _, _) => {
-                    let name = Self::get_string(function.constants[name]);
-                    world(engine).globals.insert(name);
-
-                    let instance = &mut world(engine).members[vm::world::GLOBAL];
-                    instance.entry(name).or_insert(vm::Value::from(0.0));
-                }
-
-                (code::Op::Lookup, t, name, _) => {
-                    let name = Self::get_string(function.constants[name]);
-                    registers[t].entity = if world(engine).globals.contains(&name) {
-                        vm::world::GLOBAL
-                    } else {
-                        self.self_entity
-                    };
-                }
-
-                // TODO: Replace these with `self`/`other` arguments and locals passed to `Lookup`.
-
-                (code::Op::LoadScope, t, scope, _) => {
-                    registers[t].entity = match scope as i8 as i32 {
-                        SELF => self.self_entity,
-                        OTHER => self.other_entity,
-                        GLOBAL => vm::world::GLOBAL,
-                        scope => {
-                            let kind = ErrorKind::Scope(scope);
-                            return Err(Error { symbol, instruction, kind });
-                        }
-                    };
-                }
-
-                (code::Op::StoreScope, s, scope, _) => {
-                    let s = unsafe { registers[s].entity };
-                    match scope as i8 as i32 {
-                        SELF => self.self_entity = s,
-                        OTHER => self.other_entity = s,
-                        scope => {
-                            let kind = ErrorKind::Scope(scope);
-                            return Err(Error { symbol, instruction, kind });
-                        }
-                    }
-                }
-
-                (op @ code::Op::With, ptr, end, scope) => {
-                    let scope = unsafe { registers[scope].value };
-                    let scope = match scope.data() {
-                        vm::Data::Real(scope) => Ok(Self::to_i32(scope)),
-                        scope => {
-                            let kind = ErrorKind::TypeUnary(op, scope.ty());
-                            Err(Error { symbol, instruction, kind })
-                        }
-                    }?;
-
-                    let slice = match scope {
-                        SELF => slice::from_ref(&self.self_entity),
-                        OTHER => slice::from_ref(&self.other_entity),
-                        ALL => world(engine).instances.values(),
-                        NOONE => &[],
-                        GLOBAL => slice::from_ref(&vm::world::GLOBAL),
-                        LOCAL => &[], // TODO: error
-                        object if (0..=100_000).contains(&object) =>
-                            &world(engine).objects[&object][..],
-                        instance if (100_001..).contains(&instance) =>
-                            slice::from_ref(&world(engine).instances[instance]),
-                        _ => &[], // TODO: error
-                    };
-                    unsafe {
-                        let first = slice.as_ptr() as *mut vm::Entity;
-                        let last = first.offset(slice.len() as isize);
-                        registers[ptr].iterator = ptr::NonNull::new_unchecked(first);
-                        registers[end].iterator = ptr::NonNull::new_unchecked(last);
-                    }
-                }
-
-                (code::Op::LoadPointer, t, ptr, _) => {
-                    let ptr = unsafe { registers[ptr].iterator };
-                    registers[t].entity = unsafe { *ptr.as_ptr() };
-                }
-
-                (code::Op::NextPointer, t, ptr, _) => {
-                    let ptr = unsafe { registers[ptr].iterator };
-                    registers[t].iterator = unsafe {
-                        ptr::NonNull::new_unchecked(ptr.as_ptr().offset(1))
-                    };
-                }
-
-                (code::Op::NePointer, t, a, b) => {
-                    let a = unsafe { registers[a].iterator };
-                    let b = unsafe { registers[b].iterator };
-                    registers[t].value = vm::Value::from(a != b);
-                }
-
-                (code::Op::ExistsEntity, t, entity, _) => {
-                    let entity = unsafe { registers[entity].entity };
-                    let exists = world(engine).members.contains_key(entity);
-                    registers[t].value = vm::Value::from(exists);
-                }
-
-                (op @ code::Op::Read, a, local, _) => {
-                    let a = unsafe { registers[a].value };
-                    match a.data() {
-                        vm::Data::Real(a) => {
-                            let a = Self::to_bool(a);
-                            if !a {
-                                let local = Self::get_string(function.constants[local]);
-                                let kind = ErrorKind::Name(local);
-                                return Err(Error { symbol, instruction, kind });
-                            }
-                        }
-                        a => {
-                            let kind = ErrorKind::TypeUnary(op, a.ty());
-                            return Err(Error { symbol, instruction, kind });
-                        }
-                    }
-                }
-
-                (code::Op::Write, t, a, b) => {
-                    let a = unsafe { registers[a].value };
-                    let b = unsafe { registers[b].value };
-                    registers[t].value = match b.data() {
-                        vm::Data::Array(b) => {
-                            let _ = b.store(0, 0, a);
-                            vm::Value::from(b)
-                        }
-                        _ => a
-                    };
-                }
-
-                (op @ code::Op::ScopeError, scope, _, _) => {
-                    let scope = unsafe { registers[scope].value };
-                    match scope.data() {
-                        vm::Data::Real(scope) => {
-                            let scope = Self::to_i32(scope);
-                            let kind = ErrorKind::Scope(scope);
-                            return Err(Error { symbol, instruction, kind });
-                        }
-                        scope => {
-                            let kind = ErrorKind::TypeUnary(op, scope.ty());
-                            return Err(Error { symbol, instruction, kind });
-                        }
-                    }
-                }
-
-                (code::Op::ToArray, t, a, _) => {
-                    let a = unsafe { registers[a].value };
-                    registers[t].value = match a.data() {
-                        vm::Data::Array(_) => Ok(a),
-                        _ => Ok(vm::Value::from(vm::Array::from_scalar(a))),
-                    }?;
-                }
-
-                (code::Op::ToScalar, t, a, _) => {
-                    let a = unsafe { registers[a].value };
-                    registers[t].value = match a.data() {
-                        vm::Data::Array(array) => {
-                             array.load(0, 0)
-                                .map_err(|_| {
-                                    let kind = ErrorKind::Bounds(0);
-                                    Error { symbol, instruction, kind }
-                                })?
-                        }
-                        _ => a,
-                    };
-                }
-
-                (code::Op::Release, a, _, _) => {
-                    let a = unsafe { registers[a].value };
-                    unsafe { a.release() };
-                }
-
-                (code::Op::LoadField, t, entity, field) => {
-                    let entity = unsafe { registers[entity].entity };
-                    let field = Self::get_string(function.constants[field]);
-                    let instance = &world(engine).members[entity];
-                    registers[t].value = *instance.get(&field)
-                        .ok_or_else(|| {
-                            let kind = ErrorKind::Name(field);
-                            Error { symbol, instruction, kind }
-                        })?;
-                }
-
-                (code::Op::LoadFieldDefault, t, entity, field) => {
-                    let entity = unsafe { registers[entity].entity };
-                    let field = Self::get_string(function.constants[field]);
-                    let instance = &world(engine).members[entity];
-                    registers[t].value = *instance.get(&field)
-                        .unwrap_or(&vm::Value::from(0.0));
-                }
-
-                (op @ code::Op::LoadRow, t, a, i) => {
-                    let a = unsafe { registers[a].value };
-                    let i = unsafe { registers[i].value };
-                    registers[t].row = match (a.data(), i.data()) {
-                        (vm::Data::Array(array), vm::Data::Real(i)) => {
-                            let i = Self::to_i32(i);
-                            let value = array.load_row(i)
-                                .map_err(|_| {
-                                    let kind = ErrorKind::Bounds(i);
-                                    Error { symbol, instruction, kind }
-                                })?;
-                            Ok(value)
-                        }
-                        (a, i) => {
-                            let kind = ErrorKind::TypeBinary(op, a.ty(), i.ty());
-                            Err(Error { symbol, instruction, kind })
-                        }
-                    }?;
-                }
-
-                (op @ code::Op::LoadIndex, t, r, j) => {
-                    let r = unsafe { registers[r].row };
-                    let j = unsafe { registers[j].value };
-                    registers[t].value = match j.data() {
-                        vm::Data::Real(j) => {
-                            let j = Self::to_i32(j);
-                            let value = unsafe { r.load(j) }
-                                .map_err(|_| {
-                                    let kind = ErrorKind::Bounds(j);
-                                    Error { symbol, instruction, kind }
-                                })?;
-                            Ok(value)
-                        }
-                        j => {
-                            let kind = ErrorKind::TypeBinary(op, vm::Type::Array, j.ty());
-                            Err(Error { symbol, instruction, kind })
-                        }
-                    }?;
-                }
-
-                (code::Op::StoreField, s, entity, field) => {
-                    let s = unsafe { registers[s].value };
-                    let entity = unsafe { registers[entity].entity };
-                    let field = Self::get_string(function.constants[field]);
-                    let instance = &mut world(engine).members[entity];
-                    instance.insert(field, s);
-                }
-
-                (op @ code::Op::StoreRow, t, a, i) => {
-                    let a = unsafe { registers[a].value };
-                    let i = unsafe { registers[i].value };
-                    registers[t].row = match (a.data(), i.data()) {
-                        (vm::Data::Array(array), vm::Data::Real(i)) => {
-                            let i = Self::to_i32(i);
-                            let value = array.store_row(i)
-                                .map_err(|_| {
-                                    let kind = ErrorKind::Bounds(i);
-                                    Error { symbol, instruction, kind }
-                                })?;
-                            Ok(value)
-                        }
-                        (a, i) => {
-                            let kind = ErrorKind::TypeBinary(op, a.ty(), i.ty());
-                            Err(Error { symbol, instruction, kind })
-                        }
-                    }?;
-                }
-
-                (op @ code::Op::StoreIndex, s, r, j) => {
-                    let s = unsafe { registers[s].value };
-                    let r = unsafe { registers[r].row };
-                    let j = unsafe { registers[j].value };
-                    match j.data() {
-                        vm::Data::Real(j) => {
-                            let j = Self::to_i32(j);
-                            unsafe { r.store(j, s) }
-                                .map_err(|_| {
-                                    let kind = ErrorKind::Bounds(j);
-                                    Error { symbol, instruction, kind }
-                                })?;
-                            Ok(())
-                        }
-                        j => {
-                            let kind = ErrorKind::TypeBinary(op, vm::Type::Array, j.ty());
-                            Err(Error { symbol, instruction, kind })
-                        }
-                    }?;
-                }
-
-                (code::Op::Call, callee, base, len) => {
-                    self.returns.push((symbol, instruction + 1, reg_base));
-
-                    symbol = Self::get_string(function.constants[callee]);
-                    function = &resources.scripts[&symbol];
-                    instruction = 0;
-                    reg_base = reg_base + base;
-
-                    let limit = cmp::max(function.locals as usize, len);
-                    let default = Register { value: vm::Value::from(0.0) };
-                    self.stack.resize(reg_base + limit, default);
-
-                    let registers = &mut self.stack[reg_base..];
-                    for arg in &mut registers[len..function.params as usize] {
-                        arg.value = vm::Value::from(0.0);
-                    }
-
-                    continue;
-                }
-
-                (code::Op::CallApi, callee, base, len) => {
-                    let api_symbol = Self::get_string(function.constants[callee]);
-                    let function = resources.api[&api_symbol];
-                    let reg_base = reg_base + base;
-
-                    let registers = &mut self.stack[reg_base..];
-                    let entity = self.self_entity;
-                    let arguments = unsafe { mem::transmute::<_, &[vm::Value]>(&registers[..len]) };
-                    registers[0].value = function(engine, resources, entity, arguments)
-                        .map_err(|kind| Error { symbol, instruction, kind })?;
-                }
-
-                (code::Op::CallGet, get, base, _) => {
-                    let symbol = Self::get_string(function.constants[get]);
-                    let function = resources.get.get(&symbol)
-                        .ok_or_else(|| {
-                            let kind = ErrorKind::Name(symbol);
-                            Error { symbol, instruction, kind }
-                        })?;
-                    let reg_base = reg_base + base;
-
-                    let registers = &mut self.stack[reg_base..];
-                    let entity = unsafe { registers[0].entity };
-                    let i = unsafe { registers[1].value };
-                    let i = i32::try_from(i).unwrap_or(0) as usize;
-                    registers[0].value = function(engine, entity, i);
-                }
-
-                (code::Op::CallSet, set, base, _) => {
-                    let symbol = Self::get_string(function.constants[set]);
-                    let function = resources.set.get(&symbol)
-                        .ok_or_else(|| {
-                            let kind = ErrorKind::Write(symbol);
-                            Error { symbol, instruction, kind }
-                        })?;
-                    let reg_base = reg_base + base;
-
-                    let registers = &self.stack[reg_base..];
-                    let value = unsafe { registers[0].value };
-                    let entity = unsafe { registers[1].entity };
-                    let i = unsafe { registers[2].value };
-                    let i = i32::try_from(i).unwrap_or(0) as usize;
-                    function(engine, entity, i, value);
-                }
-
-                (code::Op::Ret, _, _, _) => {
-                    let (caller, caller_instruction, caller_base) = match self.returns.pop() {
-                        Some(frame) => frame,
-                        None => {
-                            let value = unsafe { registers[0].value };
-                            return Ok(value);
-                        }
-                    };
-
-                    symbol = caller;
-                    function = &resources.scripts[&symbol];
-                    instruction = caller_instruction;
-                    reg_base = caller_base;
-
-                    let default = Register { value: vm::Value::from(0.0) };
-                    self.stack.resize(reg_base + function.locals as usize, default);
-
-                    continue;
-                }
-
-                (code::Op::Jump, t_low, t_high, _) => {
-                    instruction = t_low | (t_high << 8);
-                    continue;
-                }
-
-                (op @ code::Op::BranchFalse, a, t_low, t_high) => {
-                    let a = unsafe { registers[a].value };
-                    match a.data() {
-                        vm::Data::Real(a) => {
-                            let a = Self::to_bool(a);
-                            if !a {
-                                instruction = t_low | (t_high << 8);
-                                continue;
-                            }
-                        }
-                        a => {
-                            let kind = ErrorKind::TypeUnary(op, a.ty());
-                            return Err(Error { symbol, instruction, kind });
-                        }
-                    }
+    let kind = loop {
+        let registers = &mut thread.stack[reg_base..];
+
+        match function.instructions[instruction].decode() {
+            (code::Op::Imm, t, constant, _) => {
+                let value = function.constants[constant].clone();
+                registers[t] = Register { value: ManuallyDrop::new(value) };
+            }
+
+            (code::Op::Move, t, s, _) => {
+                // Like a Rust move, this leaves the source place uninitialized.
+                registers[t] = mem::take(&mut registers[s]);
+            }
+
+            (op @ code::Op::Neg, t, a, _) => {
+                let a = unsafe { registers[a].value_ref };
+                let value = match a.decode() {
+                    Data::Real(a) => Value::from(-a),
+                    _ => break ErrorKind::TypeUnary(op, a.clone()),
+                };
+                registers[t] = Register { value: ManuallyDrop::new(value) };
+            }
+
+            (op @ code::Op::Not, t, a, _) => {
+                let a = unsafe { registers[a].value_ref };
+                let value = match a.decode() {
+                    Data::Real(a) => Value::from(!to_bool(a)),
+                    _ => break ErrorKind::TypeUnary(op, a.clone()),
+                };
+                registers[t] = Register { value: ManuallyDrop::new(value) };
+            }
+
+            (op @ code::Op::BitNot, t, a, _) => {
+                let a = unsafe { registers[a].value_ref };
+                let value = match a.decode() {
+                    Data::Real(a) => Value::from(!to_i32(a)),
+                    _ => break ErrorKind::TypeUnary(op, a.clone()),
+                };
+                registers[t] = Register { value: ManuallyDrop::new(value) };
+            }
+
+            (op @ code::Op::Lt, t, a, b) => {
+                let a = unsafe { registers[a].value_ref };
+                let b = unsafe { registers[b].value_ref };
+                let value = match (a.decode(), b.decode()) {
+                    (Data::Real(a), Data::Real(b)) => Value::from(a < b),
+                    (Data::String(a), Data::String(b)) => Value::from(a < b),
+                    _ => break ErrorKind::TypeBinary(op, a.clone(), b.clone()),
+                };
+                registers[t] = Register { value: ManuallyDrop::new(value) };
+            }
+
+            (op @ code::Op::Le, t, a, b) => {
+                let a = unsafe { registers[a].value_ref };
+                let b = unsafe { registers[b].value_ref };
+                let value = match (a.decode(), b.decode()) {
+                    (Data::Real(a), Data::Real(b)) => Value::from(a <= b),
+                    (Data::String(a), Data::String(b)) => Value::from(a <= b),
+                    _ => break ErrorKind::TypeBinary(op, a.clone(), b.clone()),
+                };
+                registers[t] = Register { value: ManuallyDrop::new(value) };
+            }
+
+            (code::Op::Eq, t, a, b) => {
+                let a = unsafe { registers[a].value_ref };
+                let b = unsafe { registers[b].value_ref };
+                let value = Value::from(a == b);
+                registers[t] = Register { value: ManuallyDrop::new(value) };
+            }
+
+            (code::Op::Ne, t, a, b) => {
+                let a = unsafe { registers[a].value_ref };
+                let b = unsafe { registers[b].value_ref };
+                let value = Value::from(a != b);
+                registers[t] = Register { value: ManuallyDrop::new(value) };
+            }
+
+            (op @ code::Op::Ge, t, a, b) => {
+                let a = unsafe { registers[a].value_ref };
+                let b = unsafe { registers[b].value_ref };
+                let value = match (a.decode(), b.decode()) {
+                    (Data::Real(a), Data::Real(b)) => Value::from(a >= b),
+                    (Data::String(a), Data::String(b)) => Value::from(a >= b),
+                    _ => break ErrorKind::TypeBinary(op, a.clone(), b.clone()),
+                };
+                registers[t] = Register { value: ManuallyDrop::new(value) };
+            }
+
+            (op @ code::Op::Gt, t, a, b) => {
+                let a = unsafe { registers[a].value_ref };
+                let b = unsafe { registers[b].value_ref };
+                let value = match (a.decode(), b.decode()) {
+                    (Data::Real(a), Data::Real(b)) => Value::from(a > b),
+                    (Data::String(a), Data::String(b)) => Value::from(a > b),
+                    _ => break ErrorKind::TypeBinary(op, a.clone(), b.clone()),
+                };
+                registers[t] = Register { value: ManuallyDrop::new(value) };
+            }
+
+            (op @ code::Op::Add, t, a, b) => {
+                let a = unsafe { registers[a].value_ref };
+                let b = unsafe { registers[b].value_ref };
+                let value = match (a.decode(), b.decode()) {
+                    (Data::Real(a), Data::Real(b)) => Value::from(a + b),
+                    (Data::String(a), Data::String(b)) =>
+                        Value::from(Symbol::intern(&[a, b].concat())),
+                    _ => break ErrorKind::TypeBinary(op, a.clone(), b.clone()),
+                };
+                registers[t] = Register { value: ManuallyDrop::new(value) };
+            }
+
+            (op @ code::Op::Sub, t, a, b) => {
+                let a = unsafe { registers[a].value_ref };
+                let b = unsafe { registers[b].value_ref };
+                let value = match (a.decode(), b.decode()) {
+                    (Data::Real(a), Data::Real(b)) => Value::from(a - b),
+                    _ => break ErrorKind::TypeBinary(op, a.clone(), b.clone()),
+                };
+                registers[t] = Register { value: ManuallyDrop::new(value) };
+            }
+
+            (op @ code::Op::Mul, t, a, b) => {
+                let a = unsafe { registers[a].value_ref };
+                let b = unsafe { registers[b].value_ref };
+                let value = match (a.decode(), b.decode()) {
+                    (Data::Real(a), Data::Real(b)) => Value::from(a * b),
+                    (Data::Real(a), Data::String(b)) =>
+                        Value::from(Symbol::intern(&b.repeat(a as usize))),
+                    _ => break ErrorKind::TypeBinary(op, a.clone(), b.clone()),
+                };
+                registers[t] = Register { value: ManuallyDrop::new(value) };
+            }
+
+            (op @ code::Op::Div, t, a, b) => {
+                let a = unsafe { registers[a].value_ref };
+                let b = unsafe { registers[b].value_ref };
+                let value = match (a.decode(), b.decode()) {
+                    (Data::Real(_), Data::Real(b)) if b == 0.0 => break ErrorKind::DivideByZero,
+                    (Data::Real(a), Data::Real(b)) => Value::from(a / b),
+                    _ => break ErrorKind::TypeBinary(op, a.clone(), b.clone()),
+                };
+                registers[t] = Register { value: ManuallyDrop::new(value) };
+            }
+
+            (op @ code::Op::IntDiv, t, a, b) => {
+                let a = unsafe { registers[a].value_ref };
+                let b = unsafe { registers[b].value_ref };
+                let value = match (a.decode(), b.decode()) {
+                    (Data::Real(_), Data::Real(b)) if b == 0.0 => break ErrorKind::DivideByZero,
+                    (Data::Real(a), Data::Real(b)) => Value::from(to_i32(a / b)),
+                    _ => break ErrorKind::TypeBinary(op, a.clone(), b.clone()),
+                };
+                registers[t] = Register { value: ManuallyDrop::new(value) };
+            }
+
+            (op @ code::Op::Mod, t, a, b) => {
+                let a = unsafe { registers[a].value_ref };
+                let b = unsafe { registers[b].value_ref };
+                let value = match (a.decode(), b.decode()) {
+                    (Data::Real(_), Data::Real(b)) if b == 0.0 => break ErrorKind::DivideByZero,
+                    (Data::Real(a), Data::Real(b)) => Value::from(a % b),
+                    _ => break ErrorKind::TypeBinary(op, a.clone(), b.clone()),
+                };
+                registers[t] = Register { value: ManuallyDrop::new(value) };
+            }
+
+            (op @ code::Op::And, t, a, b) => {
+                let a = unsafe { registers[a].value_ref };
+                let b = unsafe { registers[b].value_ref };
+                let value = match (a.decode(), b.decode()) {
+                    (Data::Real(a), Data::Real(b)) => Value::from(to_bool(a) && to_bool(b)),
+                    _ => break ErrorKind::TypeBinary(op, a.clone(), b.clone()),
+                };
+                registers[t] = Register { value: ManuallyDrop::new(value) };
+            }
+
+            (op @ code::Op::Or, t, a, b) => {
+                let a = unsafe { registers[a].value_ref };
+                let b = unsafe { registers[b].value_ref };
+                let value = match (a.decode(), b.decode()) {
+                    (Data::Real(a), Data::Real(b)) => Value::from(to_bool(a) || to_bool(b)),
+                    _ => break ErrorKind::TypeBinary(op, a.clone(), b.clone()),
+                };
+                registers[t] = Register { value: ManuallyDrop::new(value) };
+            }
+
+            (op @ code::Op::Xor, t, a, b) => {
+                let a = unsafe { registers[a].value_ref };
+                let b = unsafe { registers[b].value_ref };
+                let value = match (a.decode(), b.decode()) {
+                    (Data::Real(a), Data::Real(b)) => Value::from(to_bool(a) != to_bool(b)),
+                    _ => break ErrorKind::TypeBinary(op, a.clone(), b.clone()),
+                };
+                registers[t] = Register { value: ManuallyDrop::new(value) };
+            }
+
+            (op @ code::Op::BitAnd, t, a, b) => {
+                let a = unsafe { registers[a].value_ref };
+                let b = unsafe { registers[b].value_ref };
+                let value = match (a.decode(), b.decode()) {
+                    (Data::Real(a), Data::Real(b)) => Value::from(to_i32(a) & to_i32(b)),
+                    _ => break ErrorKind::TypeBinary(op, a.clone(), b.clone()),
+                };
+                registers[t] = Register { value: ManuallyDrop::new(value) };
+            }
+
+            (op @ code::Op::BitOr, t, a, b) => {
+                let a = unsafe { registers[a].value_ref };
+                let b = unsafe { registers[b].value_ref };
+                let value = match (a.decode(), b.decode()) {
+                    (Data::Real(a), Data::Real(b)) => Value::from(to_i32(a) | to_i32(b)),
+                    _ => break ErrorKind::TypeBinary(op, a.clone(), b.clone()),
+                };
+                registers[t] = Register { value: ManuallyDrop::new(value) };
+            }
+
+            (op @ code::Op::BitXor, t, a, b) => {
+                let a = unsafe { registers[a].value_ref };
+                let b = unsafe { registers[b].value_ref };
+                let value = match (a.decode(), b.decode()) {
+                    (Data::Real(a), Data::Real(b)) => Value::from(to_i32(a) ^ to_i32(b)),
+                    _ => break ErrorKind::TypeBinary(op, a.clone(), b.clone()),
+                };
+                registers[t] = Register { value: ManuallyDrop::new(value) };
+            }
+
+            (op @ code::Op::ShiftLeft, t, a, b) => {
+                let a = unsafe { registers[a].value_ref };
+                let b = unsafe { registers[b].value_ref };
+                let value = match (a.decode(), b.decode()) {
+                    (Data::Real(a), Data::Real(b)) => Value::from(to_i32(a) << to_i32(b)),
+                    _ => break ErrorKind::TypeBinary(op, a.clone(), b.clone()),
+                };
+                registers[t] = Register { value: ManuallyDrop::new(value) };
+            }
+
+            (op @ code::Op::ShiftRight, t, a, b) => {
+                let a = unsafe { registers[a].value_ref };
+                let b = unsafe { registers[b].value_ref };
+                let value = match (a.decode(), b.decode()) {
+                    (Data::Real(a), Data::Real(b)) => Value::from(to_i32(a) >> to_i32(b)),
+                    _ => break ErrorKind::TypeBinary(op, a.clone(), b.clone()),
+                };
+                registers[t] = Register { value: ManuallyDrop::new(value) };
+            }
+
+            (code::Op::DeclareGlobal, name, _, _) => {
+                let name = get_string(function.constants[name].borrow());
+                world(engine).globals.insert(name);
+
+                let instance = &mut world(engine).members[world::GLOBAL];
+                instance.entry(name).or_insert(Value::from(0.0));
+            }
+
+            (code::Op::Lookup, t, name, _) => {
+                let name = get_string(function.constants[name].borrow());
+                registers[t].entity = if world(engine).globals.contains(&name) {
+                    world::GLOBAL
+                } else {
+                    thread.self_entity
+                };
+            }
+
+            // TODO: Replace these with `thread`/`other` arguments and locals passed to `Lookup`.
+
+            (code::Op::LoadScope, t, scope, _) => {
+                registers[t].entity = match scope as i8 as i32 {
+                    SELF => thread.self_entity,
+                    OTHER => thread.other_entity,
+                    GLOBAL => world::GLOBAL,
+                    scope => break ErrorKind::Scope(scope),
+                };
+            }
+
+            (code::Op::StoreScope, s, scope, _) => {
+                let s = unsafe { registers[s].entity };
+                match scope as i8 as i32 {
+                    SELF => thread.self_entity = s,
+                    OTHER => thread.other_entity = s,
+                    scope => break ErrorKind::Scope(scope),
                 }
             }
 
-            instruction += 1;
+            (op @ code::Op::With, ptr, end, scope) => {
+                let scope = unsafe { registers[scope].value_ref };
+                let scope = match scope.decode() {
+                    Data::Real(scope) => to_i32(scope),
+                    _ => break ErrorKind::TypeUnary(op, scope.clone()),
+                };
+
+                let slice = match scope {
+                    SELF => slice::from_ref(&thread.self_entity),
+                    OTHER => slice::from_ref(&thread.other_entity),
+                    ALL => world(engine).instances.values(),
+                    NOONE => &[],
+                    GLOBAL => slice::from_ref(&world::GLOBAL),
+                    LOCAL => &[], // TODO: error
+                    object if (0..=100_000).contains(&object) =>
+                        &world(engine).objects[&object][..],
+                    instance if (100_001..).contains(&instance) =>
+                        slice::from_ref(&world(engine).instances[instance]),
+                    _ => &[], // TODO: error
+                };
+                unsafe {
+                    let first = slice.as_ptr() as *mut Entity;
+                    let last = first.offset(slice.len() as isize);
+                    registers[ptr].iterator = ptr::NonNull::new_unchecked(first);
+                    registers[end].iterator = ptr::NonNull::new_unchecked(last);
+                }
+            }
+
+            (code::Op::LoadPointer, t, ptr, _) => {
+                let ptr = unsafe { registers[ptr].iterator };
+                registers[t].entity = unsafe { *ptr.as_ptr() };
+            }
+
+            (code::Op::NextPointer, t, ptr, _) => {
+                let ptr = unsafe { registers[ptr].iterator };
+                registers[t].iterator = unsafe {
+                    ptr::NonNull::new_unchecked(ptr.as_ptr().offset(1))
+                };
+            }
+
+            (code::Op::NePointer, t, a, b) => {
+                let a = unsafe { registers[a].iterator };
+                let b = unsafe { registers[b].iterator };
+                let value = Value::from(a != b);
+                registers[t] = Register { value: ManuallyDrop::new(value) };
+            }
+
+            (code::Op::ExistsEntity, t, entity, _) => {
+                let entity = unsafe { registers[entity].entity };
+                let exists = world(engine).members.contains_key(entity);
+                let value = Value::from(exists);
+                registers[t] = Register { value: ManuallyDrop::new(value) };
+            }
+
+            // Despite its name, this opcode does not actually read any language-level values.
+            // Instead it checks whether a local variable is initialized *before* it is read.
+            (op @ code::Op::Read, a, local, _) => {
+                let a = unsafe { registers[a].value_ref };
+                match a.decode() {
+                    Data::Real(a) => if !to_bool(a) {
+                        let local = get_string(function.constants[local].borrow());
+                        break ErrorKind::Name(local);
+                    }
+                    _ => break ErrorKind::TypeUnary(op, a.clone()),
+                }
+            }
+
+            // This is a particularly inscrutable opcode, designed to handle pre-GM:S unindexed
+            // writes to array variables: it overwrites `b` or `b[0, 0]` with `a.clone()` and moves
+            // the result to `t`.
+            (code::Op::Write, t, ai, bi) => {
+                let a = unsafe { registers[ai].value_ref };
+                let b = unsafe { registers[bi].value_ref };
+                registers[t] = match b.decode() {
+                    Data::Array(array) => {
+                        array.set_jagged(0, 0, a.clone());
+                        mem::take(&mut registers[bi])
+                    }
+                    _ => Register { value: ManuallyDrop::new(a.clone()) }
+                };
+            }
+
+            (op @ code::Op::ScopeError, scope, _, _) => {
+                let scope = unsafe { registers[scope].value_ref };
+                match scope.decode() {
+                    Data::Real(scope) => break ErrorKind::Scope(to_i32(scope)),
+                    _ => break ErrorKind::TypeUnary(op, scope.clone()),
+                }
+            }
+
+            (code::Op::ToArray, t, a, _) => {
+                let a = unsafe { registers[a].value_ref };
+                let value = match a.decode() {
+                    Data::Array(_) => a.clone(),
+                    _ => Value::from(Array::from_scalar(a.clone())),
+                };
+                registers[t] = Register { value: ManuallyDrop::new(value) };
+            }
+
+            (op @ code::Op::ToScalar, t, a, _) => {
+                let a = unsafe { registers[a].value_ref };
+                let value = match a.decode() {
+                    Data::Array(array) => match array.get_jagged(0, 0) {
+                        // The result of this operation *must* be a scalar to preserve GML
+                        // semantics. This check guards against problems when mixing versions.
+                        Some(a) => match a.borrow().decode() {
+                            Data::Array(_) => break ErrorKind::TypeUnary(op, a),
+                            _ => a,
+                        }
+                        None => break ErrorKind::Bounds(0),
+                    }
+                    // Because `a` is not an array, this clone is a simple copy.
+                    _ => a.clone(),
+                };
+                registers[t] = Register { value: ManuallyDrop::new(value) };
+            }
+
+            (code::Op::Release, a, _, _) => unsafe {
+                ManuallyDrop::drop(&mut registers[a].value);
+            }
+
+            (code::Op::LoadField, t, entity, field) => {
+                let entity = unsafe { registers[entity].entity };
+                let field = get_string(function.constants[field].borrow());
+                let instance = &world(engine).members[entity];
+                let value = match instance.get(&field) {
+                    Some(value) => value.borrow(),
+                    None => break ErrorKind::Name(field),
+                };
+                registers[t].value_ref = unsafe { erase_ref(value) };
+            }
+
+            (code::Op::LoadFieldDefault, t, entity, field) => {
+                let entity = unsafe { registers[entity].entity };
+                let field = get_string(function.constants[field].borrow());
+                let instance = &world(engine).members[entity];
+                let value = match instance.get(&field) {
+                    Some(value) => value.borrow(),
+                    None => ValueRef::default(),
+                };
+                registers[t].value_ref = unsafe { erase_ref(value) };
+            }
+
+            (op @ code::Op::LoadRow, t, a, i) => {
+                let a = unsafe { registers[a].value_ref };
+                let i = unsafe { registers[i].value_ref };
+                let row = match (a.decode(), i.decode()) {
+                    (Data::Array(array), Data::Real(i)) => match array.get_raw(to_i32(i)) {
+                        // TODO: consider soundness here
+                        Some(value) => match unsafe { (*value).borrow().decode() } {
+                            Data::Array(array) => array,
+                            _ => break ErrorKind::TypeUnary(op, a.clone()),
+                        }
+                        None => break ErrorKind::Bounds(to_i32(i)),
+                    }
+                    _ => break ErrorKind::TypeBinary(op, a.clone(), i.clone()),
+                };
+                registers[t].row = row;
+            }
+
+            (op @ code::Op::LoadIndex, t, r, j) => {
+                let r = unsafe { registers[r].row };
+                let j = unsafe { registers[j].value_ref };
+                let value = match j.decode() {
+                    Data::Real(j) => match r.get_raw(to_i32(j)) {
+                        // TODO: consider soundness here
+                        Some(value) => unsafe { (*value).borrow() }
+                        None => break ErrorKind::Bounds(to_i32(j)),
+                    }
+                    _ => break ErrorKind::TypeBinary(op, Value::from(r.clone()), j.clone()),
+                };
+                registers[t].value_ref = unsafe { erase_ref(value) };
+            }
+
+            (code::Op::StoreField, s, entity, field) => {
+                let s = unsafe { registers[s].value_ref };
+                let entity = unsafe { registers[entity].entity };
+                let field = get_string(function.constants[field].borrow());
+                let instance = &mut world(engine).members[entity];
+                instance.insert(field, s.clone());
+            }
+
+            (op @ code::Op::StoreRow, t, a, i) => {
+                let a = unsafe { registers[a].value_ref };
+                let i = unsafe { registers[i].value_ref };
+                let row = match (a.decode(), i.decode()) {
+                    (Data::Array(array), Data::Real(i)) => match array.set_raw_outer(to_i32(i)) {
+                        // TODO: consider soundness here
+                        Some(value) => match unsafe { (*value).borrow().decode() } {
+                            Data::Array(array) => array,
+                            _ => break ErrorKind::TypeUnary(op, a.clone())
+                        }
+                        None => break ErrorKind::Bounds(to_i32(i)),
+                    }
+                    _ => break ErrorKind::TypeBinary(op, a.clone(), i.clone()),
+                };
+                registers[t].row = row;
+            }
+
+            (op @ code::Op::StoreIndex, s, r, j) => {
+                let s = unsafe { registers[s].value_ref };
+                let r = unsafe { registers[r].row };
+                let j = unsafe { registers[j].value_ref };
+                match j.decode() {
+                    Data::Real(j) => match r.set_flat(to_i32(j), s.clone()) {
+                        Some(()) => {}
+                        None => break ErrorKind::Bounds(to_i32(j)),
+                    }
+                    _ => break ErrorKind::TypeBinary(op, Value::from(r.clone()), j.clone()),
+                }
+            }
+
+            (code::Op::Call, callee, base, len) => {
+                thread.returns.push((symbol, instruction + 1, reg_base));
+
+                symbol = get_string(function.constants[callee].borrow());
+                function = &resources.scripts[&symbol];
+                instruction = 0;
+                reg_base = reg_base + base;
+
+                let limit = cmp::max(function.locals as usize, len);
+                thread.stack.resize_with(reg_base + limit, Register::default);
+
+                let registers = thread.stack[reg_base..][..function.params as usize].iter_mut();
+                for reg in registers.skip(len) {
+                    *reg = Register { value: ManuallyDrop::new(Value::default()) };
+                }
+
+                continue;
+            }
+
+            (code::Op::CallApi, callee, base, len) => {
+                let api_symbol = get_string(function.constants[callee].borrow());
+                let function = resources.api[&api_symbol];
+                let reg_base = reg_base + base;
+
+                let registers = &mut thread.stack[reg_base..];
+                let entity = thread.self_entity;
+                let arguments = unsafe { mem::transmute::<_, &[Value]>(&registers[..len]) };
+                let value = match function(engine, resources, entity, arguments) {
+                    Ok(value) => value,
+                    Err(kind) => break kind,
+                };
+                registers[0] = Register { value: ManuallyDrop::new(value) };
+            }
+
+            (code::Op::CallGet, get, base, _) => {
+                let symbol = get_string(function.constants[get].borrow());
+                let function = match resources.get.get(&symbol) {
+                    Some(function) => function,
+                    None => break ErrorKind::Name(symbol),
+                };
+                let reg_base = reg_base + base;
+
+                let registers = &mut thread.stack[reg_base..];
+                let entity = unsafe { registers[0].entity };
+                let i = unsafe { registers[1].value_ref };
+                let i = i32::try_from(i).unwrap_or(0) as usize;
+                let value = function(engine, entity, i);
+                registers[0] = Register { value: ManuallyDrop::new(value) };
+            }
+
+            (code::Op::CallSet, set, base, _) => {
+                let symbol = get_string(function.constants[set].borrow());
+                let function = match resources.set.get(&symbol) {
+                    Some(function) => function,
+                    None => break ErrorKind::Write(symbol),
+                };
+                let reg_base = reg_base + base;
+
+                let registers = &thread.stack[reg_base..];
+                let value = unsafe { registers[0].value_ref };
+                let entity = unsafe { registers[1].entity };
+                let i = unsafe { registers[2].value_ref };
+                let i = i32::try_from(i).unwrap_or(0) as usize;
+                function(engine, entity, i, value);
+            }
+
+            (code::Op::Ret, _, _, _) => {
+                let (caller, caller_instruction, caller_base) = match thread.returns.pop() {
+                    Some(frame) => frame,
+                    None => {
+                        let value = unsafe { registers[0].value_ref };
+                        return Ok(value.clone());
+                    }
+                };
+
+                symbol = caller;
+                function = &resources.scripts[&symbol];
+                instruction = caller_instruction;
+                reg_base = caller_base;
+
+                thread.stack.resize_with(reg_base + function.locals as usize, Register::default);
+
+                continue;
+            }
+
+            (code::Op::Jump, t_low, t_high, _) => {
+                instruction = t_low | (t_high << 8);
+                continue;
+            }
+
+            (op @ code::Op::BranchFalse, a, t_low, t_high) => {
+                let a = unsafe { registers[a].value_ref };
+                match a.decode() {
+                    Data::Real(a) => if !to_bool(a) {
+                        instruction = t_low | (t_high << 8);
+                        continue;
+                    }
+                    _ => break ErrorKind::TypeUnary(op, a.clone()),
+                }
+            }
         }
-    }
 
-    // TODO: round-to-nearest instead of truncate
-    pub fn to_i32(value: f64) -> i32 {
-        value as i32
-    }
+        instruction += 1;
+    };
 
-    // TODO: round-to-nearest instead of truncate
-    pub fn to_u32(value: f64) -> u32 {
-        value as u32
-    }
-
-    pub fn to_bool(value: f64) -> bool {
-        Self::to_i32(value) > 0
-    }
-
-    fn get_string(value: vm::Value) -> Symbol {
-        match value.data() {
-            vm::Data::String(value) => value,
-            _ => unreachable!("expected a string"),
-        }
-    }
+    Err(Error { symbol, instruction, kind })
 }

--- a/gml/src/vm/mod.rs
+++ b/gml/src/vm/mod.rs
@@ -5,8 +5,8 @@ use crate::symbol::Symbol;
 pub use crate::vm::interpreter::{Thread, Error, ErrorKind, SELF, OTHER, ALL, NOONE, GLOBAL};
 pub use crate::vm::world::World;
 pub use crate::vm::entity_map::{Entity, EntityAllocator, EntityMap};
-pub use crate::vm::value::{Type, Value, Data};
-pub use crate::vm::array::{Array, Row};
+pub use crate::vm::value::{Value, ValueRef, Data, to_i32, to_u32, to_bool};
+pub use crate::vm::array::{Array, ArrayRef};
 
 pub mod code;
 pub mod debug;
@@ -27,7 +27,7 @@ pub struct Resources<E: ?Sized> {
 
 pub type ApiFunction<E> = fn(&mut E, &Resources<E>, Entity, &[Value]) -> Result<Value, ErrorKind>;
 pub type GetFunction<E> = fn(&mut E, Entity, usize) -> Value;
-pub type SetFunction<E> = fn(&mut E, Entity, usize, Value);
+pub type SetFunction<E> = fn(&mut E, Entity, usize, ValueRef);
 
 impl<E: ?Sized> Default for Resources<E> {
     fn default() -> Self {

--- a/gml/src/vm/value.rs
+++ b/gml/src/vm/value.rs
@@ -1,227 +1,256 @@
-use std::{mem, fmt, f64};
-use std::num::NonZeroUsize;
+use std::{hint, mem, cmp, fmt};
 use std::convert::TryFrom;
+use std::marker::PhantomData;
+use std::num::NonZeroUsize;
 
 use crate::symbol::Symbol;
 use crate::vm;
 
 /// A GML value.
 ///
-/// Values are NaN-boxed, representing either an `f64` or a tagged value. The encoding favors
+/// Values are NaN-boxed, representing either an `f64` or some tagged value. This encoding favors
 /// `f64`s, assuming that GML will use them most frequently. Other types are stored as NaN
 /// payloads.
 ///
 /// To avoid ambiguity, NaNs are canonicalized. The hardware seems to use positive qNaN with a zero
-/// payload (0x7ff8_0000_0000_0000), so other types are encoded as negative NaNs, leaving 52 bits
-/// for tag and value (including the quiet bit- we ensure the payload is non-zero elsewhere).
+/// payload (0x7ff8_0000_0000_0000), so other types are encoded as negative qNaNs, leaving 51 bits
+/// for tag and value. This means we can check for a NaN-boxed value with an integer comparison.
 ///
 /// By limiting ourselves to 48-bit pointers (the current limit on x86_64 and AArch64, and a nice
-/// round number for sign extension), we get 4 bits for a tag. This could be expanded to 5 bits by
-/// exploiting the fact that typical kernels only give positive addresses to user space. For
-/// pointer values only, another 3-5 bits could be taken from the LSB end by aligning allocations.
+/// round number for sign extension), we get 3 bits for a tag. Pointer values could additionally
+/// use their lower bits by aligning allocations, if 3 bits is not enough.
 ///
-/// 4-bit tag values:
-/// 0000 - string
-/// 0001 - array
-///
-/// 1000 - canonical NaN
-#[derive(Copy, Clone, PartialEq, Eq, Hash)]
+/// 3-bit tag values:
+/// 000 - string
+/// 001 - array
+#[derive(Eq, PartialEq, Hash)]
+#[repr(transparent)]
 pub struct Value(u64);
 
-pub enum Data {
+/// An un-owned GML value.
+///
+/// A `ValueRef` has the capabilities of a `&Value` with the representation of a `Value`. This
+/// sacrifices pointer identity (two `ValueRef`s cannot tell whether they borrow from the same
+/// `Value`) and some conveniences (&/* syntax and auto-(de)ref) for a more direct and efficient
+/// calling convention.
+#[derive(Copy, Clone, Eq, PartialEq, Hash)]
+#[repr(transparent)]
+pub struct ValueRef<'a> {
+    value: u64,
+    _marker: PhantomData<&'a Value>,
+}
+
+/// A convenient, unpacked version of a `ValueRef`.
+pub enum Data<'a> {
     Real(f64),
     String(Symbol),
-    Array(vm::Array),
+    Array(vm::ArrayRef<'a>),
 }
 
-#[derive(Copy, Clone, PartialEq, Eq, Hash, Debug)]
-pub enum Type {
-    Real,
-    String,
-    Array,
-}
-
-impl Value {
-    pub fn data(self) -> Data {
-        let Value(value) = self;
-
-        // This check covers finite, infinite, and positive NaN reals.
-        // Negative NaN is handled below with tagged values.
-        if value <= 0xfff0_0000_0000_0000 {
-            return Data::Real(f64::from_bits(value));
-        }
-
-        let tag = value >> 48;
-        let payload = value & ((1 << 48) - 1);
-        match tag & 0xf {
-            // Safety: String values are always constructed from non-zero `Symbol`s.
-            // (The check above also excludes cases where both `tag & 0xf` and `payload` are zero.)
-            0x0 => Data::String(Symbol::from_index(unsafe {
-                NonZeroUsize::new_unchecked(payload as usize)
-            })),
-
-            0x1 => Data::Array(unsafe { vm::Array::clone_from_raw(payload as *const _) }),
-
-            0x8 => Data::Real(f64::from_bits(value)),
-            _ => unreachable!("corrupt value"),
-        }
-    }
-
-    pub unsafe fn release(self) {
-        let Value(value) = self;
-        let tag = value >> 48;
-        let payload = value & ((1 << 48) - 1);
-
-        if tag & !0xf != 0xfff0 {
-            return;
-        }
-
-        match tag & 0xf {
-            0x0 => (),
-            0x1 => { vm::Array::from_raw(payload as *const _); },
-            _ => unreachable!("corrupt value"),
-        }
-    }
-}
-
-impl Data {
-    pub fn ty(&self) -> Type {
-        match *self {
-            Data::Real(_) => Type::Real,
-            Data::String(_) => Type::String,
-            Data::Array(_) => Type::Array,
-        }
-    }
+impl Default for Value {
+    fn default() -> Self { Self::from(0.0) }
 }
 
 impl From<f64> for Value {
     fn from(value: f64) -> Value {
-        // TODO: check for non-canonical NaNs
-        let value = unsafe { mem::transmute::<_, u64>(value) };
-
+        // Canonicalize any NaNs that overlap our tagged value space.
+        let value = cmp::min(f64::to_bits(value), 0xfff8_0000_0000_0000);
         Value(value)
     }
 }
 
 impl From<Symbol> for Value {
     fn from(value: Symbol) -> Value {
-        let tag = 0xfff0 | 0x0;
-        let value = value.into_index().get() as u64;
-
-        Value((tag << 48) | value)
+        let tag = 0xfff8 | 0b000;
+        Value((tag << 48) | value.into_index().get() as u64)
     }
 }
 
 impl From<vm::Array> for Value {
     fn from(value: vm::Array) -> Value {
-        let tag = 0xfff0 | 0x1;
-        let value = value.into_raw() as u64;
-
-        Value((tag << 48) | value)
+        let tag = 0xfff8 | 0b001;
+        Value((tag << 48) | value.into_raw() as u64)
     }
 }
 
-impl From<()> for Value {
-    fn from(_: ()) -> Value {
-        Value::from(0.0)
+impl Clone for Value {
+    fn clone(&self) -> Value { self.borrow().clone() }
+}
+
+impl Drop for Value {
+    fn drop(&mut self) {
+        match self.borrow().decode() {
+            // Safety: `self` was constructed from a full `Array`.
+            Data::Real(_) | Data::String(_) => {}
+            Data::Array(array) => unsafe { let _ = vm::Array::from_raw(array.as_raw()); }
+        }
     }
 }
 
-impl From<f32> for Value {
-    fn from(value: f32) -> Value {
-        Value::from(value as f64)
+impl Value {
+    /// Convert a `&Value` into a `ValueRef`.
+    pub fn borrow(&self) -> ValueRef<'_> {
+        let Value(value) = *self;
+        ValueRef { value, _marker: PhantomData }
     }
-}
 
-impl From<i32> for Value {
-    fn from(value: i32) -> Value {
-        Value::from(value as f64)
+    /// Convert a `Value` into a `ValueRef<'static>`.
+    pub fn leak(self) -> ValueRef<'static> {
+        let Value(value) = self;
+        ValueRef { value, _marker: PhantomData }
     }
-}
 
-impl From<u32> for Value {
-    fn from(value: u32) -> Value {
-        Value::from(value as f64)
-    }
-}
+    pub fn into_raw(self) -> u64 { let Value(value) = self; value }
 
-impl From<bool> for Value {
-    fn from(value: bool) -> Value {
-        Value::from(value as i32)
-    }
+    pub unsafe fn from_raw(raw: u64) -> Value { Value(raw) }
 }
 
 impl fmt::Debug for Value {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result { self.borrow().fmt(f) }
+}
+
+impl Default for ValueRef<'_> {
+    fn default() -> Self { Value::default().leak() }
+}
+
+impl<'a> ValueRef<'a> {
+    /// Convert this borrowed value into an owned value.
+    pub fn clone(self) -> Value {
+        match self.decode() {
+            Data::Real(_) | Data::String(_) => Value(self.value),
+            Data::Array(array) => Value::from(array.clone()),
+        }
+    }
+
+    /// Unpack a `ValueRef` into a type Rust code can work with.
+    pub fn decode(self) -> Data<'a> {
+        let ValueRef { value, .. } = self;
+
+        // This is our canonical NaN. All tagged values are above it; it is the highest real.
+        if value <= 0xfff8_0000_0000_0000 {
+            return Data::Real(f64::from_bits(value));
+        }
+
+        let tag = value >> 48;
+        let payload = value & ((1 << 48) - 1);
+        match tag & 0b111 {
+            // Safety: String values are always constructed from non-zero `Symbol`s.
+            0b000 => unsafe {
+                let payload = NonZeroUsize::new_unchecked(payload as usize);
+                Data::String(Symbol::from_index(payload))
+            }
+
+            // Safety: The returned `ArrayRef` borrows from `self`.
+            0b001 => unsafe { Data::Array(vm::ArrayRef::from_raw(payload as *const _)) }
+
+            // Safety: A `Value` cannot be constructed with any other tag value.
+            _ => unsafe { hint::unreachable_unchecked() }
+        }
+    }
+}
+
+impl AsRef<Value> for ValueRef<'_> {
+    /// Convert a `ValueRef` into a `&Value`.
+    ///
+    /// Note that we cannot offer the more-permissive reborrow-style variant that converts a
+    /// `ValueRef<'a>` to a `&'a Value`, because we do not actually have the address of a real
+    /// `Value`.
+    fn as_ref(&self) -> &Value {
+        // Safety: `Value` and `ValueRef` are `#[repr(transparent)]` and contain a single `u64`.
+        //
+        // The return value borrows from `self`, so even though it does not actually point to the
+        // original `Value` it will still be prevented from outliving it.
+        unsafe { mem::transmute::<&ValueRef<'_>, &Value>(self) }
+    }
+}
+
+impl fmt::Debug for ValueRef<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let visited = Default::default();
         vm::debug::Value { value: *self, visited: &visited }.fmt(f)
     }
 }
 
-pub struct TryFromValueError(());
+// Common type conversions that need special handling to match GM:
 
-impl TryFrom<Value> for f64 {
+// TODO: round-to-nearest instead of truncate
+pub fn to_i32(value: f64) -> i32 { value as i32 }
+
+// TODO: round-to-nearest instead of truncate
+pub fn to_u32(value: f64) -> u32 { value as u32 }
+
+pub fn to_bool(value: f64) -> bool { to_i32(value) > 0 }
+
+// `From` and `TryFrom` impls to marshal values in and out of API bindings:
+
+impl From<()> for Value { fn from(_: ()) -> Value { Value::from(0.0) } }
+
+impl From<f32> for Value { fn from(value: f32) -> Value { Value::from(value as f64) } }
+
+impl From<i32> for Value { fn from(value: i32) -> Value { Value::from(value as f64) } }
+
+impl From<u32> for Value { fn from(value: u32) -> Value { Value::from(value as f64) } }
+
+impl From<bool> for Value { fn from(value: bool) -> Value { Value::from(value as i32) } }
+
+pub struct TryFromValueError;
+
+impl TryFrom<ValueRef<'_>> for f64 {
     type Error = TryFromValueError;
-
-    fn try_from(value: Value) -> Result<f64, Self::Error> {
-        match value.data() {
+    fn try_from(value: ValueRef<'_>) -> Result<f64, Self::Error> {
+        match value.decode() {
             vm::Data::Real(i) => Ok(i),
-            _ => Err(TryFromValueError(())),
+            _ => Err(TryFromValueError),
         }
     }
 }
 
-impl TryFrom<Value> for Symbol {
+impl TryFrom<ValueRef<'_>> for Symbol {
     type Error = TryFromValueError;
-
-    fn try_from(value: Value) -> Result<Symbol, Self::Error> {
-        match value.data() {
+    fn try_from(value: ValueRef<'_>) -> Result<Symbol, Self::Error> {
+        match value.decode() {
             vm::Data::String(s) => Ok(s),
-            _ => Err(TryFromValueError(())),
+            _ => Err(TryFromValueError)
         }
     }
 }
 
-impl TryFrom<Value> for f32 {
+impl TryFrom<ValueRef<'_>> for f32 {
     type Error = TryFromValueError;
-
-    fn try_from(value: Value) -> Result<f32, Self::Error> {
-        match value.data() {
+    fn try_from(value: ValueRef<'_>) -> Result<f32, Self::Error> {
+        match value.decode() {
             vm::Data::Real(i) => Ok(i as f32),
-            _ => Err(TryFromValueError(())),
+            _ => Err(TryFromValueError)
         }
     }
 }
 
-impl TryFrom<Value> for i32 {
+impl TryFrom<ValueRef<'_>> for i32 {
     type Error = TryFromValueError;
-
-    fn try_from(value: Value) -> Result<i32, Self::Error> {
-        match value.data() {
-            vm::Data::Real(i) => Ok(vm::Thread::to_i32(i)),
-            _ => Err(TryFromValueError(())),
+    fn try_from(value: ValueRef<'_>) -> Result<i32, Self::Error> {
+        match value.decode() {
+            vm::Data::Real(i) => Ok(vm::to_i32(i)),
+            _ => Err(TryFromValueError),
         }
     }
 }
 
-impl TryFrom<Value> for u32 {
+impl TryFrom<ValueRef<'_>> for u32 {
     type Error = TryFromValueError;
-
-    fn try_from(value: Value) -> Result<u32, Self::Error> {
-        match value.data() {
-            vm::Data::Real(i) => Ok(vm::Thread::to_u32(i)),
-            _ => Err(TryFromValueError(())),
+    fn try_from(value: ValueRef<'_>) -> Result<u32, Self::Error> {
+        match value.decode() {
+            vm::Data::Real(i) => Ok(vm::to_u32(i)),
+            _ => Err(TryFromValueError),
         }
     }
 }
 
-impl TryFrom<Value> for bool {
+impl TryFrom<ValueRef<'_>> for bool {
     type Error = TryFromValueError;
-
-    fn try_from(value: Value) -> Result<bool, Self::Error> {
-        match value.data() {
-            vm::Data::Real(i) => Ok(vm::Thread::to_bool(i)),
-            _ => Err(TryFromValueError(())),
+    fn try_from(value: ValueRef<'_>) -> Result<bool, Self::Error> {
+        match value.decode() {
+            vm::Data::Real(i) => Ok(vm::to_bool(i)),
+            _ => Err(TryFromValueError),
         }
     }
 }
@@ -234,40 +263,34 @@ mod tests {
     #[test]
     fn reals() {
         let value = vm::Value::from(0.0);
-        assert!(match value.data() { vm::Data::Real(x) if x == 0.0 => true, _ => false });
+        assert!(matches!(value.borrow().decode(), vm::Data::Real(x) if x == 0.0));
 
         let value = vm::Value::from(3.5);
-        assert!(match value.data() { vm::Data::Real(x) if x == 3.5 => true, _ => false });
+        assert!(matches!(value.borrow().decode(), vm::Data::Real(x) if x == 3.5));
 
         let value = vm::Value::from(f64::INFINITY);
-        assert!(match value.data() {
-            vm::Data::Real(x) if x == f64::INFINITY => true,
-            _ => false
-        });
+        assert!(matches!(value.borrow().decode(), vm::Data::Real(x) if x == f64::INFINITY));
 
         let value = vm::Value::from(f64::NEG_INFINITY);
-        assert!(match value.data() {
-            vm::Data::Real(x) if x == f64::NEG_INFINITY => true,
-            _ => false
-        });
+        assert!(matches!(value.borrow().decode(), vm::Data::Real(x) if x == f64::NEG_INFINITY));
 
         let value = vm::Value::from(f64::NAN);
-        assert!(match value.data() { vm::Data::Real(x) if f64::is_nan(x) => true, _ => false });
+        assert!(matches!(value.borrow().decode(), vm::Data::Real(x) if f64::is_nan(x)));
     }
 
     #[test]
     fn strings() {
         let value = vm::Value::from(Symbol::intern("true"));
-        assert!(match value.data() { vm::Data::String(keyword::True) => true, _ => false });
+        assert!(matches!(value.borrow().decode(), vm::Data::String(keyword::True)));
 
         let value = vm::Value::from(Symbol::intern("argument0"));
-        assert!(match value.data() {
-            vm::Data::String(x) if x == Symbol::from_argument(0) => true,
-            _ => false
-        });
+        assert!(matches!(
+            value.borrow().decode(),
+            vm::Data::String(x) if x == Symbol::from_argument(0)
+        ));
 
         let symbol = Symbol::intern("foo");
         let value = vm::Value::from(symbol);
-        assert!(match value.data() { vm::Data::String(x) if x == symbol => true, _ => false });
+        assert!(matches!(value.borrow().decode(), vm::Data::String(x) if x == symbol));
     }
 }

--- a/gml/tests/interpreter.rs
+++ b/gml/tests/interpreter.rs
@@ -15,16 +15,16 @@ fn arguments() -> Result<(), vm::Error> {
 
     let resources = build(&items).unwrap_or_else(|_| panic!());
     let mut engine = Engine::default();
-    let mut thread = vm::Thread::new();
+    let mut thread = vm::Thread::default();
 
-    let arguments = [vm::Value::from(3), vm::Value::from(5)];
-    assert_eq!(thread.execute(&mut engine, &resources, select, &arguments)?, vm::Value::from(8));
+    let arguments = vec![vm::Value::from(3), vm::Value::from(5)];
+    assert_eq!(thread.execute(&mut engine, &resources, select, arguments)?, vm::Value::from(8));
 
     let a = Symbol::intern("a");
     let b = Symbol::intern("b");
     let ab = Symbol::intern("ab");
-    let arguments = [vm::Value::from(a), vm::Value::from(b)];
-    assert_eq!(thread.execute(&mut engine, &resources, select, &arguments)?, vm::Value::from(ab));
+    let arguments = vec![vm::Value::from(a), vm::Value::from(b)];
+    assert_eq!(thread.execute(&mut engine, &resources, select, arguments)?, vm::Value::from(ab));
 
     Ok(())
 }
@@ -45,12 +45,12 @@ fn member() -> Result<(), vm::Error> {
 
     let resources = build(&items).unwrap_or_else(|_| panic!());
     let mut engine = Engine::default();
-    let mut thread = vm::Thread::new();
+    let mut thread = vm::Thread::default();
 
     let entity = engine.world.create_instance(0, 100001);
     thread.set_self(entity);
 
-    assert_eq!(thread.execute(&mut engine, &resources, member, &[])?, vm::Value::from(8));
+    assert_eq!(thread.execute(&mut engine, &resources, member, vec![])?, vm::Value::from(8));
     Ok(())
 }
 
@@ -84,13 +84,13 @@ fn builtin() -> Result<(), vm::Error> {
 
     let resources = build(&items).unwrap_or_else(|_| panic!());
     let mut engine = Engine::default();
-    let mut thread = vm::Thread::new();
+    let mut thread = vm::Thread::default();
 
     let entity = engine.world.create_instance(0, 100001);
     engine.instances.insert(entity, Instance::default());
     thread.set_self(entity);
 
-    assert_eq!(thread.execute(&mut engine, &resources, builtin, &[])?, vm::Value::from(34));
+    assert_eq!(thread.execute(&mut engine, &resources, builtin, vec![])?, vm::Value::from(34));
 
     let instance = &engine.instances[&entity];
     assert_eq!(instance.scalar, 3.0);
@@ -118,12 +118,12 @@ fn global() -> Result<(), vm::Error> {
 
     let resources = build(&items).unwrap_or_else(|_| panic!());
     let mut engine = Engine::default();
-    let mut thread = vm::Thread::new();
+    let mut thread = vm::Thread::default();
 
     let entity = engine.world.create_instance(0, 100001);
     thread.set_self(entity);
 
-    assert_eq!(thread.execute(&mut engine, &resources, global, &[])?, vm::Value::from(8));
+    assert_eq!(thread.execute(&mut engine, &resources, global, vec![])?, vm::Value::from(8));
     Ok(())
 }
 
@@ -152,13 +152,13 @@ fn with() -> Result<(), vm::Error> {
 
     let resources = build(&items).unwrap_or_else(|_| panic!());
     let mut engine = Engine::default();
-    let mut thread = vm::Thread::new();
+    let mut thread = vm::Thread::default();
 
     let a = engine.world.create_instance(0, 100001);
     engine.world.create_instance(0, 100002);
     thread.set_self(a);
 
-    assert_eq!(thread.execute(&mut engine, &resources, with, &[])?, vm::Value::from(24.0));
+    assert_eq!(thread.execute(&mut engine, &resources, with, vec![])?, vm::Value::from(24.0));
     Ok(())
 }
 
@@ -180,9 +180,9 @@ fn array() -> Result<(), vm::Error> {
 
     let resources = build(&items).unwrap_or_else(|_| panic!());
     let mut engine = Engine::default();
-    let mut thread = vm::Thread::new();
+    let mut thread = vm::Thread::default();
 
-    assert_eq!(thread.execute(&mut engine, &resources, array, &[])?, vm::Value::from(50));
+    assert_eq!(thread.execute(&mut engine, &resources, array, vec![])?, vm::Value::from(50));
     Ok(())
 }
 
@@ -241,9 +241,9 @@ fn for_loop() -> Result<(), vm::Error> {
 
     let resources = build(&items).unwrap_or_else(|_| panic!());
     let mut engine = Engine::default();
-    let mut thread = vm::Thread::new();
+    let mut thread = vm::Thread::default();
 
-    assert_eq!(thread.execute(&mut engine, &resources, factorial, &[])?, vm::Value::from(24));
+    assert_eq!(thread.execute(&mut engine, &resources, factorial, vec![])?, vm::Value::from(24));
     Ok(())
 }
 
@@ -269,19 +269,19 @@ fn switch() -> Result<(), vm::Error> {
 
     let resources = build(&items).unwrap_or_else(|_| panic!());
     let mut engine = Engine::default();
-    let mut thread = vm::Thread::new();
+    let mut thread = vm::Thread::default();
 
-    let arguments = [vm::Value::from(3)];
-    assert_eq!(thread.execute(&mut engine, &resources, switch, &arguments)?, vm::Value::from(5));
+    let arguments = vec![vm::Value::from(3)];
+    assert_eq!(thread.execute(&mut engine, &resources, switch, arguments)?, vm::Value::from(5));
 
-    let arguments = [vm::Value::from(8)];
-    assert_eq!(thread.execute(&mut engine, &resources, switch, &arguments)?, vm::Value::from(13));
+    let arguments = vec![vm::Value::from(8)];
+    assert_eq!(thread.execute(&mut engine, &resources, switch, arguments)?, vm::Value::from(13));
 
-    let arguments = [vm::Value::from(21)];
-    assert_eq!(thread.execute(&mut engine, &resources, switch, &arguments)?, vm::Value::from(21));
+    let arguments = vec![vm::Value::from(21)];
+    assert_eq!(thread.execute(&mut engine, &resources, switch, arguments)?, vm::Value::from(21));
 
-    let arguments = [vm::Value::from(34)];
-    assert_eq!(thread.execute(&mut engine, &resources, switch, &arguments)?, vm::Value::from(21));
+    let arguments = vec![vm::Value::from(34)];
+    assert_eq!(thread.execute(&mut engine, &resources, switch, arguments)?, vm::Value::from(21));
 
     Ok(())
 }
@@ -322,19 +322,19 @@ fn switch_fallthrough() -> Result<(), vm::Error> {
 
     let resources = build(&items).unwrap_or_else(|_| panic!());
     let mut engine = Engine::default();
-    let mut thread = vm::Thread::new();
+    let mut thread = vm::Thread::default();
 
-    let arguments = [vm::Value::from(0)];
-    assert_eq!(thread.execute(&mut engine, &resources, switch, &arguments)?, vm::Value::from(0));
+    let arguments = vec![vm::Value::from(0)];
+    assert_eq!(thread.execute(&mut engine, &resources, switch, arguments)?, vm::Value::from(0));
 
-    let arguments = [vm::Value::from(1)];
-    assert_eq!(thread.execute(&mut engine, &resources, switch, &arguments)?, vm::Value::from(8));
+    let arguments = vec![vm::Value::from(1)];
+    assert_eq!(thread.execute(&mut engine, &resources, switch, arguments)?, vm::Value::from(8));
 
-    let arguments = [vm::Value::from(2)];
-    assert_eq!(thread.execute(&mut engine, &resources, switch, &arguments)?, vm::Value::from(5));
+    let arguments = vec![vm::Value::from(2)];
+    assert_eq!(thread.execute(&mut engine, &resources, switch, arguments)?, vm::Value::from(5));
 
-    let arguments = [vm::Value::from(3)];
-    assert_eq!(thread.execute(&mut engine, &resources, switch, &arguments)?, vm::Value::from(5));
+    let arguments = vec![vm::Value::from(3)];
+    assert_eq!(thread.execute(&mut engine, &resources, switch, arguments)?, vm::Value::from(5));
 
     Ok(())
 }
@@ -352,9 +352,9 @@ fn call_script() -> Result<(), vm::Error> {
 
     let resources = build(&items).unwrap_or_else(|_| panic!());
     let mut engine = Engine::default();
-    let mut thread = vm::Thread::new();
+    let mut thread = vm::Thread::default();
 
-    assert_eq!(thread.execute(&mut engine, &resources, call, &[])?, vm::Value::from(8));
+    assert_eq!(thread.execute(&mut engine, &resources, call, vec![])?, vm::Value::from(8));
     Ok(())
 }
 
@@ -374,10 +374,10 @@ fn recurse() -> Result<(), vm::Error> {
 
     let resources = build(&items).unwrap_or_else(|_| panic!());
     let mut engine = Engine::default();
-    let mut thread = vm::Thread::new();
+    let mut thread = vm::Thread::default();
 
-    let arguments = [vm::Value::from(6)];
-    assert_eq!(thread.execute(&mut engine, &resources, fibonacci, &arguments)?, vm::Value::from(13));
+    let arguments = vec![vm::Value::from(6)];
+    assert_eq!(thread.execute(&mut engine, &resources, fibonacci, arguments)?, vm::Value::from(13));
     Ok(())
 }
 
@@ -402,9 +402,9 @@ fn ffi() -> Result<(), vm::Error> {
 
     let resources = build(&items).unwrap_or_else(|_| panic!());
     let mut engine = Engine::default();
-    let mut thread = vm::Thread::new();
+    let mut thread = vm::Thread::default();
 
-    assert_eq!(thread.execute(&mut engine, &resources, caller, &[])?, vm::Value::from(16.0));
+    assert_eq!(thread.execute(&mut engine, &resources, caller, vec![])?, vm::Value::from(16.0));
     Ok(())
 }
 
@@ -426,7 +426,7 @@ impl Engine {
     fn native_add(
         &mut self, _resources: &vm::Resources<Engine>, _entity: vm::Entity, arguments: &[vm::Value]
     ) -> Result<vm::Value, vm::ErrorKind> {
-        let value = match (arguments[0].data(), arguments[1].data()) {
+        let value = match (arguments[0].borrow().decode(), arguments[1].borrow().decode()) {
             (vm::Data::Real(a), vm::Data::Real(b)) => vm::Value::from(a + b),
             _ => vm::Value::from(0),
         };
@@ -437,14 +437,14 @@ impl Engine {
     fn get_global_scalar(&mut self, _: vm::Entity, _: usize) -> vm::Value {
         vm::Value::from(self.global_scalar)
     }
-    fn set_global_scalar(&mut self, _: vm::Entity, _: usize, value: vm::Value) {
+    fn set_global_scalar(&mut self, _: vm::Entity, _: usize, value: vm::ValueRef) {
         self.global_scalar = i32::try_from(value).unwrap_or(0);
     }
 
     fn get_global_array(&mut self, _: vm::Entity, i: usize) -> vm::Value {
         vm::Value::from(self.global_array[i] as f64)
     }
-    fn set_global_array(&mut self, _: vm::Entity, i: usize, value: vm::Value) {
+    fn set_global_array(&mut self, _: vm::Entity, i: usize, value: vm::ValueRef) {
         self.global_array[i] = f64::try_from(value).unwrap_or(0.0) as f32;
     }
 }
@@ -460,7 +460,7 @@ impl Instance {
         let instance = &engine.instances[&entity];
         vm::Value::from(instance.scalar as f64)
     }
-    pub fn set_scalar(engine: &mut Engine, entity: vm::Entity, _: usize, value: vm::Value) {
+    pub fn set_scalar(engine: &mut Engine, entity: vm::Entity, _: usize, value: vm::ValueRef) {
         let instance = engine.instances.get_mut(&entity).unwrap();
         instance.scalar = f64::try_from(value).unwrap_or(0.0) as f32;
     }
@@ -469,7 +469,7 @@ impl Instance {
         let instance = &engine.instances[&entity];
         vm::Value::from(instance.array[i])
     }
-    pub fn set_array(engine: &mut Engine, entity: vm::Entity, i: usize, value: vm::Value) {
+    pub fn set_array(engine: &mut Engine, entity: vm::Entity, i: usize, value: vm::ValueRef) {
         let instance = engine.instances.get_mut(&entity).unwrap();
         instance.array[i] = i32::try_from(value).unwrap_or(0);
     }

--- a/playground/src/lib.rs
+++ b/playground/src/lib.rs
@@ -39,9 +39,9 @@ pub fn run(source: &str) {
     let id = engine.instance.instance_create(&mut engine.world, &mut engine.motion, 0.0, 0.0, 0)
         .unwrap_or_else(|_| panic!("object does not exist"));
 
-    let mut thread = gml::vm::Thread::new();
+    let mut thread = gml::vm::Thread::default();
     thread.set_self(engine.world.instances[id]);
-    if let Err(error) = thread.execute(&mut engine, &resources, script, &[]) {
+    if let Err(error) = thread.execute(&mut engine, &resources, script, vec![]) {
         let location = resources.debug[&error.symbol].get_location(error.instruction as u32);
         let lines = match items[&error.symbol] {
             gml::Item::Event(source) => Lines::from_event(source),

--- a/runner/src/main.rs
+++ b/runner/src/main.rs
@@ -63,7 +63,7 @@ fn main() {
 
     let resources = gml::build(&items).unwrap_or_else(|_| panic!());
     let mut engine = Engine::default();
-    let mut thread = gml::vm::Thread::new();
+    let mut thread = gml::vm::Thread::default();
 
     let id = engine.instance.instance_create(&mut engine.world, &mut engine.motion, 0.0, 0.0, 0)
         .unwrap_or_else(|_| panic!("object does not exist"));
@@ -72,7 +72,7 @@ fn main() {
     engine.instance.instance_create(&mut engine.world, &mut engine.motion, 0.0, 0.0, 1)
         .unwrap_or_else(|_| panic!("object does not exist"));
 
-    if let Err(error) = thread.execute(&mut engine, &resources, main, &[]) {
+    if let Err(error) = thread.execute(&mut engine, &resources, main, vec![]) {
         let location = resources.debug[&error.symbol].get_location(error.instruction as u32);
         let lines = match items[&error.symbol] {
             gml::Item::Script(source) => Lines::from_script(source),


### PR DESCRIPTION
This moves us closer to a sound and safe API as discussed in #40. Because
a `vm::Value` may point to an array, users must check its type and perhaps
increment its refcount anywhere they duplicate the value.

As part of overhauling `vm::Value`, this commit also slightly tweaks the
NaN-boxing scheme. The quiet bit is now always set, moving tagged values
up to the top of the available bit-pattern range. This simplifies decoding
such that all real values are contiguous. (See #43)

To avoid introducing new, redundant refcount traffic, there are now also
`vm::ValueRef` and `vm::ArrayRef` types that share a representation with
their owned counterparts, but can only exist as a borrow.

The interpreter relies entirely on codegen to provide it with sound
bytecode that does not violate host language rules. This means that each
opcode handler must carefully choose whether to borrow, move, or clone its
operands, so that codegen can rely on that behavior.