### PR TITLE
M2/Arm Fixes with Latest Rust

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,8 +34,8 @@ jobs:
         targets: wasm32-unknown-unknown
     - name: Binaryen
       run: |
-        curl -s -L https://github.com/WebAssembly/binaryen/releases/download/version_110/binaryen-version_110-x86_64-linux.tar.gz | tar -xzf - -C ~
-        echo "$HOME/binaryen-version_110/bin" >> $GITHUB_PATH
+        curl -s -L https://github.com/WebAssembly/binaryen/releases/download/version_112/binaryen-version_112-x86_64-linux.tar.gz | tar -xzf - -C ~
+        echo "$HOME/binaryen-version_112/bin" >> $GITHUB_PATH
     - name: Checkout
       uses: actions/checkout@v3
     - name: Build

--- a/gml/src/lib.rs
+++ b/gml/src/lib.rs
@@ -1,5 +1,4 @@
 #![feature(box_patterns)]
-#![feature(box_syntax)]
 #![feature(extern_types)]
 
 use std::collections::HashMap;


### PR DESCRIPTION
Delete unused box_syntax feature that was unstable feature and has been removed.

Literally all it took for me to build this on my new MacBook Pro.
```
   Compiling project v0.1.0 (/Users/owner/Downloads/dejavu-main/project)
   Compiling gml-meta v0.1.0 (/Users/owner/Downloads/dejavu-main/gml/meta)
   Compiling gml v0.1.0 (/Users/owner/Downloads/dejavu-main/gml)
error[E0557]: feature has been removed
 --> gml/src/lib.rs:2:12
  |
2 | #![feature(box_syntax)]
  |            ^^^^^^^^^^ feature has been removed
  |
  = note: replaced with `#[rustc_box]`

For more information about this error, try `rustc --explain E0557`.
error: could not compile `gml` (lib) due to previous error
...
owner@Owners-MBP dejavu-main % cargo build
   Compiling gml v0.1.0 (/Users/owner/Downloads/dejavu-main/gml)
   Compiling runner v0.1.0 (/Users/owner/Downloads/dejavu-main/runner)
   Compiling loader v0.1.0 (/Users/owner/Downloads/dejavu-main/runner/loader)
    Finished dev [unoptimized + debuginfo] target(s) in 4.27s
owner@Owners-MBP dejavu-main % cargo run -- project.gmk
    Finished dev [unoptimized + debuginfo] target(s) in 0.01s
     Running `target/debug/loader project.gmk`
Error: Os { code: 2, kind: NotFound, message: "No such file or directory" }
owner@Owners-MBP dejavu-main % cd target/debug
owner@Owners-MBP debug % touch test_mbp.gml
owner@Owners-MBP debug % code test_mbp.gml
zsh: command not found: code
owner@Owners-MBP debug % vscode
zsh: command not found: vscode
owner@Owners-MBP debug % cargo run -- test_mbp.gml
    Finished dev [unoptimized + debuginfo] target(s) in 0.01s
     Running `./loader test_mbp.gml`
Hello Dejavu from M2! 
owner@Owners-MBP debug % 
```